### PR TITLE
feat: add reusable side panel shell

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useMemo, useState, useEffect } from "react";
+import { SidePanel } from "@tessera/ui-components";
 import { CollaborativeEditor } from "./components/CollaborativeEditor.js";
 import {
   useCollaboration,
@@ -19,6 +20,7 @@ export function App() {
   const participant = useMemo(() => createDefaultParticipant(), []);
   const [language, setLanguage] = useState<SupportedLanguage>("typescript");
   const [isRunning, setIsRunning] = useState(false);
+  const [isAiPanelOpen, setIsAiPanelOpen] = useState(false);
   const [output, setOutput] = useState<ExecutionResult | null>(null);
 
   const config = useMemo<SyncConnectionConfig>(
@@ -109,6 +111,14 @@ export function App() {
             )}
           </button>
 
+          <button
+            type="button"
+            onClick={() => setIsAiPanelOpen(true)}
+            className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1 text-sm font-semibold text-slate-200 transition hover:border-tessera-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-tessera-500"
+          >
+            AI Panel
+          </button>
+
           {/* Connection Indicator */}
           <div className="flex items-center gap-2 border-l border-[var(--color-border)] pl-4">
             <span
@@ -183,6 +193,17 @@ export function App() {
           )}
         </div>
       </div>
+
+      <SidePanel
+        open={isAiPanelOpen}
+        title="AI Chat"
+        description={`Context: ${FILE_NAMES[language]}`}
+        onClose={() => setIsAiPanelOpen(false)}
+      >
+        <div className="rounded border border-dashed border-[var(--color-border)] bg-[var(--color-bg)] p-4 text-sm text-slate-400">
+          Ready for editor context.
+        </div>
+      </SidePanel>
     </div>
   );
 }

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@source "../../../packages/ui-components/src";
 
 @theme {
   --font-sans: "Inter", system-ui, sans-serif;

--- a/packages/ui-components/src/SidePanel.tsx
+++ b/packages/ui-components/src/SidePanel.tsx
@@ -1,0 +1,59 @@
+import type { ReactNode } from "react";
+
+export interface SidePanelProps {
+  readonly open: boolean;
+  readonly title: string;
+  readonly children: ReactNode;
+  readonly onClose: () => void;
+  readonly description?: string;
+  readonly footer?: ReactNode;
+  readonly className?: string;
+}
+
+export function SidePanel({
+  open,
+  title,
+  children,
+  onClose,
+  description,
+  footer,
+  className = "",
+}: SidePanelProps) {
+  return (
+    <aside
+      aria-hidden={!open}
+      aria-label={title}
+      inert={!open ? true : undefined}
+      className={`fixed inset-y-0 right-0 z-40 flex w-full max-w-md transform flex-col border-l border-[var(--color-border)] bg-[var(--color-surface)] shadow-2xl shadow-black/40 transition-transform duration-200 ease-out ${
+        open ? "translate-x-0" : "pointer-events-none translate-x-full"
+      } ${className}`}
+    >
+      <header className="flex min-h-14 items-start justify-between gap-4 border-b border-[var(--color-border)] px-4 py-3">
+        <div className="min-w-0">
+          <h2 className="truncate text-sm font-semibold text-white">{title}</h2>
+          {description ? (
+            <p className="mt-0.5 line-clamp-2 text-xs text-slate-400">
+              {description}
+            </p>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          aria-label={`Close ${title}`}
+          onClick={onClose}
+          className="grid h-8 w-8 shrink-0 place-items-center rounded border border-[var(--color-border)] bg-[var(--color-bg)] text-lg leading-none text-slate-300 transition hover:border-tessera-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-tessera-500"
+        >
+          ×
+        </button>
+      </header>
+
+      <div className="flex-1 overflow-y-auto px-4 py-4">{children}</div>
+
+      {footer ? (
+        <footer className="border-t border-[var(--color-border)] px-4 py-3">
+          {footer}
+        </footer>
+      ) : null}
+    </aside>
+  );
+}

--- a/packages/ui-components/src/index.ts
+++ b/packages/ui-components/src/index.ts
@@ -1,9 +1,4 @@
-// ──────────────────────────────────────────────────────────────
-// @tessera/ui-components — Reusable UI component stubs
-// ──────────────────────────────────────────────────────────────
+export { SidePanel } from "./SidePanel.js";
+export type { SidePanelProps } from "./SidePanel.js";
 
-/**
- * Placeholder barrel export for UI components.
- * Components will be added here as the design system is built out.
- */
 export const UI_COMPONENTS_VERSION = "0.1.0" as const;


### PR DESCRIPTION
## Summary

Adds a reusable `SidePanel` UI shell that slides in from the right side of the editor and wires it into the web app behind an `AI Panel` toggle.

Closes #50

## Root Cause

The editor UI did not have a reusable right-side panel shell for future AI chat content, so any AI panel integration would need to invent layout, close controls, and scrolling behavior from scratch.

## Changes Made

- Added a reusable `SidePanel` component to `@tessera/ui-components`.
- Exported the component and props from the shared UI package barrel.
- Added Tailwind source scanning for shared UI package classes.
- Added an `AI Panel` header button in the web app that opens the side panel.
- Included an accessible header, close button, optional description, body slot, and optional footer slot.
- Kept closed panels inert and non-interactive while preserving the slide-in shell behavior.

## Testing

- `npm ci`
- `npm run typecheck --workspace @tessera/ui-components`
- `npm run typecheck --workspace @tessera/web`
- `npm run build`
- `git diff --check`
- Browser smoke at `http://127.0.0.1:3000/`: opened the AI Panel, verified the `AI Chat` panel content, closed it through the DOM-visible close control, and checked zero console errors.

## Impact

Future AI chat work can mount content inside a consistent, reusable right-side editor panel without duplicating layout or accessibility handling.

## Notes

`npm ci` reports existing moderate audit warnings. The production build also keeps the existing Vite large chunk warning from the Monaco/editor bundle.
