### PR TITLE
feat: add AI service API client

### DIFF
--- a/apps/web/src/services/aiService.test.ts
+++ b/apps/web/src/services/aiService.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  AiServiceError,
+  getAiServiceHealth,
+  ingestRagDocument,
+  searchRagChunks,
+} from "./aiService.js";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+    ...init,
+  });
+}
+
+describe("aiService", () => {
+  it("calls the health endpoint with a normalized base URL", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ status: "ok" }),
+    );
+
+    await expect(
+      getAiServiceHealth({
+        baseUrl: "http://localhost:8000/",
+        fetcher,
+      }),
+    ).resolves.toEqual({ status: "ok" });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://localhost:8000/health",
+      expect.objectContaining({
+        method: "GET",
+      }),
+    );
+  });
+
+  it("posts typed RAG ingest payloads", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({ chunks_stored: 2 }),
+    );
+
+    await expect(
+      ingestRagDocument(
+        {
+          file_path: "src/App.tsx",
+          content: "const app = true;",
+          chunk_size: 128,
+        },
+        {
+          baseUrl: "http://localhost:8000",
+          fetcher,
+        },
+      ),
+    ).resolves.toEqual({ chunks_stored: 2 });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://localhost:8000/rag/ingest",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          file_path: "src/App.tsx",
+          content: "const app = true;",
+          chunk_size: 128,
+        }),
+      }),
+    );
+  });
+
+  it("posts typed RAG search payloads", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      jsonResponse({
+        results: [
+          {
+            file_path: "src/App.tsx",
+            content: "const app = true;",
+            score: 0.98,
+          },
+        ],
+      }),
+    );
+
+    await expect(
+      searchRagChunks(
+        {
+          query_vector: [0.1, 0.2, 0.3],
+          top_k: 3,
+        },
+        {
+          baseUrl: "http://localhost:8000",
+          fetcher,
+        },
+      ),
+    ).resolves.toEqual({
+      results: [
+        {
+          file_path: "src/App.tsx",
+          content: "const app = true;",
+          score: 0.98,
+        },
+      ],
+    });
+
+    expect(fetcher).toHaveBeenCalledWith(
+      "http://localhost:8000/rag/search",
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({
+          query_vector: [0.1, 0.2, 0.3],
+          top_k: 3,
+        }),
+      }),
+    );
+  });
+
+  it("throws a typed error for non-2xx responses", async () => {
+    const fetcher = vi.fn<typeof fetch>().mockResolvedValue(
+      new Response("missing collection", {
+        status: 503,
+        statusText: "Service Unavailable",
+      }),
+    );
+
+    const request = getAiServiceHealth({
+      baseUrl: "http://localhost:8000",
+      fetcher,
+    });
+
+    await expect(request).rejects.toBeInstanceOf(AiServiceError);
+    await expect(request).rejects.toMatchObject({
+      name: "AiServiceError",
+      status: 503,
+      responseBody: "missing collection",
+    });
+  });
+});

--- a/apps/web/src/services/aiService.ts
+++ b/apps/web/src/services/aiService.ts
@@ -1,0 +1,113 @@
+const DEFAULT_AI_SERVICE_URL = "http://127.0.0.1:8000";
+
+export interface AiServiceClientOptions {
+  readonly baseUrl?: string;
+  readonly fetcher?: typeof fetch;
+}
+
+export interface HealthResponse {
+  readonly status: string;
+}
+
+export interface RagIngestRequest {
+  readonly file_path: string;
+  readonly content: string;
+  readonly chunk_size?: number;
+}
+
+export interface RagIngestResponse {
+  readonly chunks_stored: number;
+}
+
+export interface RagSearchRequest {
+  readonly query_vector: readonly number[];
+  readonly top_k?: number;
+}
+
+export interface RagChunkResult {
+  readonly file_path: string;
+  readonly content: string;
+  readonly score: number;
+}
+
+export interface RagSearchResponse {
+  readonly results: readonly RagChunkResult[];
+}
+
+export class AiServiceError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+    readonly responseBody: string,
+  ) {
+    super(message);
+    this.name = "AiServiceError";
+  }
+}
+
+function resolveBaseUrl(baseUrl?: string): string {
+  const configuredUrl =
+    baseUrl ?? import.meta.env.VITE_AI_SERVICE_URL ?? DEFAULT_AI_SERVICE_URL;
+  return configuredUrl.replace(/\/+$/, "");
+}
+
+async function requestJson<TResponse>(
+  path: string,
+  init: RequestInit,
+  options: AiServiceClientOptions = {},
+): Promise<TResponse> {
+  const fetcher = options.fetcher ?? fetch;
+  const response = await fetcher(`${resolveBaseUrl(options.baseUrl)}${path}`, {
+    headers: {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+    ...init,
+  });
+
+  if (!response.ok) {
+    const responseBody = await response.text();
+    throw new AiServiceError(
+      `AI service request failed with ${response.status}`,
+      response.status,
+      responseBody,
+    );
+  }
+
+  return response.json() as Promise<TResponse>;
+}
+
+export function getAiServiceHealth(
+  options?: AiServiceClientOptions,
+): Promise<HealthResponse> {
+  return requestJson<HealthResponse>("/health", { method: "GET" }, options);
+}
+
+export function ingestRagDocument(
+  request: RagIngestRequest,
+  options?: AiServiceClientOptions,
+): Promise<RagIngestResponse> {
+  return requestJson<RagIngestResponse>(
+    "/rag/ingest",
+    {
+      method: "POST",
+      body: JSON.stringify(request),
+    },
+    options,
+  );
+}
+
+export function searchRagChunks(
+  request: RagSearchRequest,
+  options?: AiServiceClientOptions,
+): Promise<RagSearchResponse> {
+  return requestJson<RagSearchResponse>(
+    "/rag/search",
+    {
+      method: "POST",
+      body: JSON.stringify(request),
+    },
+    options,
+  );
+}


### PR DESCRIPTION
## Summary

Adds a typed web client for the AI service endpoints requested in #49.

Closes #49

## Root Cause

The web app did not have a centralized client for the FastAPI AI service, so future UI work would need to duplicate fetch calls and endpoint payload shapes for health checks, RAG ingestion, and RAG search.

## Changes Made

- Added `apps/web/src/services/aiService.ts`.
- Added typed client functions for:
  - `GET /health`
  - `POST /rag/ingest`
  - `POST /rag/search`
- Matched request and response types to the existing FastAPI models.
- Added `VITE_AI_SERVICE_URL` support with a local `http://127.0.0.1:8000` default.
- Added a typed `AiServiceError` for non-2xx responses.
- Added unit tests covering URL normalization, ingest payloads, search payloads, and error handling.

## Testing

- `npm run test --workspace @tessera/web`
- `npm run typecheck --workspace @tessera/web`
- `npm run build`
- `git diff --check`

## Impact

Future AI chat and RAG UI work can call the AI service through one typed module instead of repeating raw fetch logic across components.

## Notes

The production build still reports the existing Vite large chunk warning from the Monaco/editor bundle.
