### PR TITLE
feat: log AI service request timings

### DIFF
--- a/apps/ai-service/src/main.py
+++ b/apps/ai-service/src/main.py
@@ -1,10 +1,15 @@
+import logging
 from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
-from fastapi import FastAPI
+from time import perf_counter
+
+from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from .db import connect_db, close_db
 from .rag import router as rag_router
 from .mcp_server import mcp
+
+logger = logging.getLogger("tessera.ai.timing")
 
 
 @asynccontextmanager
@@ -27,6 +32,35 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.middleware("http")
+async def log_request_timing(request: Request, call_next):
+    start = perf_counter()
+
+    try:
+        response = await call_next(request)
+    except Exception:
+        duration_ms = (perf_counter() - start) * 1000
+        logger.exception(
+            "ai_service_request_failed method=%s path=%s duration_ms=%.2f",
+            request.method,
+            request.url.path,
+            duration_ms,
+        )
+        raise
+
+    duration_ms = (perf_counter() - start) * 1000
+    response.headers["X-Process-Time-Ms"] = f"{duration_ms:.2f}"
+    logger.info(
+        "ai_service_request method=%s path=%s status_code=%s duration_ms=%.2f",
+        request.method,
+        request.url.path,
+        response.status_code,
+        duration_ms,
+    )
+    return response
+
 
 app.include_router(rag_router)
 app.mount("/mcp", mcp.sse_app())


### PR DESCRIPTION
## Summary

Adds FastAPI request timing middleware for the AI service so incoming AI/RAG calls emit duration metrics.

Closes #40

## Root Cause

The AI service did not record request duration, making it harder to identify slow RAG search or ingestion calls during development and operations.

## Changes Made

- Added HTTP middleware in `apps/ai-service/src/main.py`.
- Measures each request with `perf_counter()`.
- Adds an `X-Process-Time-Ms` response header.
- Logs method, path, status code, and duration for successful requests.
- Logs method, path, and duration with exception context when request handling fails.

## Testing

- `python3 -m py_compile apps/ai-service/src/main.py`
- `npm run lint --workspace @tessera/ai-service`
- `npm run build --workspace @tessera/ai-service`
- `npm run build`
- `git diff --check`

## Impact

AI/RAG endpoints now expose useful latency telemetry without changing endpoint behavior or response bodies.

## Notes

The root build keeps the existing Vite large chunk warning from the Monaco/editor bundle. Turbo also reports that the Python AI-service build has no output files, which matches the existing package build script.
