### PR TITLE
feat: initialize MongoDB indexes on AI service startup

### DIFF
--- a/apps/ai-service/src/db.py
+++ b/apps/ai-service/src/db.py
@@ -1,9 +1,19 @@
 from time import perf_counter
+import logging
 
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
+from pymongo import ASCENDING
+from pymongo.errors import CollectionInvalid, OperationFailure
+from pymongo.operations import SearchIndexModel
+
 from .config import settings
 
 _client: AsyncIOMotorClient | None = None  # type: ignore[type-arg]
+_logger = logging.getLogger(__name__)
+
+VECTOR_SEARCH_INDEX_NAME = "vector_index"
+FILE_PATH_INDEX_NAME = "file_path_idx"
+FILE_PATH_CHUNK_INDEX_NAME = "file_path_chunk_index_idx"
 
 
 async def connect_db() -> None:
@@ -58,3 +68,79 @@ async def check_connection() -> dict[str, object]:
     status["connected"] = True
     status["latency_ms"] = round((perf_counter() - start) * 1000, 2)
     return status
+
+
+async def ensure_collection_indexes() -> None:
+    if _client is None:
+        raise RuntimeError("Database not connected. Call connect_db() first.")
+
+    db = _client[settings.MONGODB_DB_NAME]
+
+    if settings.MONGODB_COLLECTION not in await db.list_collection_names():
+        try:
+            await db.create_collection(settings.MONGODB_COLLECTION)
+        except CollectionInvalid:
+            # Another startup worker may have created the collection first.
+            pass
+
+    collection = db[settings.MONGODB_COLLECTION]
+    await collection.create_index(
+        [("file_path", ASCENDING)],
+        name=FILE_PATH_INDEX_NAME,
+        background=True,
+    )
+    await collection.create_index(
+        [("file_path", ASCENDING), ("chunk_index", ASCENDING)],
+        name=FILE_PATH_CHUNK_INDEX_NAME,
+        background=True,
+    )
+    await _ensure_vector_search_index(collection)
+
+
+async def _ensure_vector_search_index(
+    collection: AsyncIOMotorCollection,  # type: ignore[type-arg]
+) -> None:
+    if await _has_vector_search_index(collection):
+        return
+
+    index_model = SearchIndexModel(
+        definition={
+            "fields": [
+                {
+                    "type": "vector",
+                    "path": "embedding",
+                    "numDimensions": settings.EMBEDDING_DIMENSIONS,
+                    "similarity": "cosine",
+                }
+            ]
+        },
+        name=VECTOR_SEARCH_INDEX_NAME,
+        type="vectorSearch",
+    )
+
+    try:
+        await collection.create_search_index(model=index_model)
+    except (AttributeError, OperationFailure) as exc:
+        _logger.warning(
+            "Skipping MongoDB vector search index creation for %s: %s",
+            settings.MONGODB_COLLECTION,
+            exc,
+        )
+
+
+async def _has_vector_search_index(
+    collection: AsyncIOMotorCollection,  # type: ignore[type-arg]
+) -> bool:
+    try:
+        async for index in collection.list_search_indexes():
+            if index.get("name") == VECTOR_SEARCH_INDEX_NAME:
+                return True
+    except (AttributeError, OperationFailure) as exc:
+        _logger.warning(
+            "Skipping MongoDB search index inspection for %s: %s",
+            settings.MONGODB_COLLECTION,
+            exc,
+        )
+        return True
+
+    return False

--- a/apps/ai-service/src/db.py
+++ b/apps/ai-service/src/db.py
@@ -13,14 +13,15 @@ _logger = logging.getLogger(__name__)
 
 VECTOR_SEARCH_INDEX_NAME = "vector_index"
 FILE_PATH_INDEX_NAME = "file_path_idx"
-FILE_PATH_CHUNK_INDEX_NAME = "file_path_chunk_index_idx"
+FILE_PATH_CHUNK_INDEX_NAME = "file_path_chunk_idx"
 _DUPLICATE_INDEX_ERROR_CODES = {68, 85, 86, 11000}
+_UNSUPPORTED_SEARCH_INDEX_ERROR_CODES = {40324}
 _DUPLICATE_INDEX_ERROR_MARKERS = (
     "already exists",
     "duplicate",
-    "IndexAlreadyExists",
-    "IndexKeySpecsConflict",
-    "IndexOptionsConflict",
+    "indexalreadyexists",
+    "indexkeyspecsconflict",
+    "indexoptionsconflict",
 )
 
 
@@ -91,15 +92,39 @@ async def ensure_collection_indexes() -> None:
         pass
 
     collection = db[settings.MONGODB_COLLECTION]
-    await collection.create_index(
+    await _ensure_standard_index(
+        collection,
         [("file_path", ASCENDING)],
-        name=FILE_PATH_INDEX_NAME,
+        FILE_PATH_INDEX_NAME,
     )
-    await collection.create_index(
+    await _ensure_standard_index(
+        collection,
         [("file_path", ASCENDING), ("chunk_index", ASCENDING)],
-        name=FILE_PATH_CHUNK_INDEX_NAME,
+        FILE_PATH_CHUNK_INDEX_NAME,
     )
     await _ensure_vector_search_index(collection)
+    _logger.info(
+        "MongoDB indexes ensured for collection %s",
+        settings.MONGODB_COLLECTION,
+    )
+
+
+async def _ensure_standard_index(
+    collection: AsyncIOMotorCollection,  # type: ignore[type-arg]
+    keys: list[tuple[str, int]],
+    name: str,
+) -> None:
+    try:
+        await collection.create_index(keys, name=name)
+    except OperationFailure as exc:
+        if _is_duplicate_index_error(exc):
+            return
+        _logger.warning(
+            "Skipping MongoDB index creation for %s.%s: %s",
+            settings.MONGODB_COLLECTION,
+            name,
+            exc,
+        )
 
 
 async def _ensure_vector_search_index(
@@ -148,20 +173,38 @@ async def _has_vector_search_index(
         async for index in collection.list_search_indexes():
             if index.get("name") == VECTOR_SEARCH_INDEX_NAME:
                 return True
-    except (AttributeError, OperationFailure) as exc:
+    except AttributeError as exc:
         _logger.warning(
             "Skipping MongoDB search index inspection for %s: %s",
             settings.MONGODB_COLLECTION,
             exc,
         )
         return True
+    except OperationFailure as exc:
+        if _is_search_index_unsupported_error(exc):
+            _logger.warning(
+                "Skipping MongoDB search index inspection for %s: %s",
+                settings.MONGODB_COLLECTION,
+                exc,
+            )
+            return True
+        _logger.warning(
+            "MongoDB search index inspection failed for %s: %s",
+            settings.MONGODB_COLLECTION,
+            exc,
+        )
+        return False
 
     return False
+
+
+def _is_search_index_unsupported_error(exc: OperationFailure) -> bool:
+    return exc.code in _UNSUPPORTED_SEARCH_INDEX_ERROR_CODES
 
 
 def _is_duplicate_index_error(exc: OperationFailure) -> bool:
     if exc.code in _DUPLICATE_INDEX_ERROR_CODES:
         return True
 
-    error_text = str(exc)
+    error_text = str(exc).lower()
     return any(marker in error_text for marker in _DUPLICATE_INDEX_ERROR_MARKERS)

--- a/apps/ai-service/src/db.py
+++ b/apps/ai-service/src/db.py
@@ -14,6 +14,14 @@ _logger = logging.getLogger(__name__)
 VECTOR_SEARCH_INDEX_NAME = "vector_index"
 FILE_PATH_INDEX_NAME = "file_path_idx"
 FILE_PATH_CHUNK_INDEX_NAME = "file_path_chunk_index_idx"
+_DUPLICATE_INDEX_ERROR_CODES = {68, 85, 86, 11000}
+_DUPLICATE_INDEX_ERROR_MARKERS = (
+    "already exists",
+    "duplicate",
+    "IndexAlreadyExists",
+    "IndexKeySpecsConflict",
+    "IndexOptionsConflict",
+)
 
 
 async def connect_db() -> None:
@@ -76,23 +84,20 @@ async def ensure_collection_indexes() -> None:
 
     db = _client[settings.MONGODB_DB_NAME]
 
-    if settings.MONGODB_COLLECTION not in await db.list_collection_names():
-        try:
-            await db.create_collection(settings.MONGODB_COLLECTION)
-        except CollectionInvalid:
-            # Another startup worker may have created the collection first.
-            pass
+    try:
+        await db.create_collection(settings.MONGODB_COLLECTION)
+    except CollectionInvalid:
+        # The collection already exists, or another startup worker created it.
+        pass
 
     collection = db[settings.MONGODB_COLLECTION]
     await collection.create_index(
         [("file_path", ASCENDING)],
         name=FILE_PATH_INDEX_NAME,
-        background=True,
     )
     await collection.create_index(
         [("file_path", ASCENDING), ("chunk_index", ASCENDING)],
         name=FILE_PATH_CHUNK_INDEX_NAME,
-        background=True,
     )
     await _ensure_vector_search_index(collection)
 
@@ -120,7 +125,15 @@ async def _ensure_vector_search_index(
 
     try:
         await collection.create_search_index(model=index_model)
-    except (AttributeError, OperationFailure) as exc:
+    except AttributeError as exc:
+        _logger.warning(
+            "Skipping MongoDB vector search index creation for %s: %s",
+            settings.MONGODB_COLLECTION,
+            exc,
+        )
+    except OperationFailure as exc:
+        if _is_duplicate_index_error(exc):
+            return
         _logger.warning(
             "Skipping MongoDB vector search index creation for %s: %s",
             settings.MONGODB_COLLECTION,
@@ -144,3 +157,11 @@ async def _has_vector_search_index(
         return True
 
     return False
+
+
+def _is_duplicate_index_error(exc: OperationFailure) -> bool:
+    if exc.code in _DUPLICATE_INDEX_ERROR_CODES:
+        return True
+
+    error_text = str(exc)
+    return any(marker in error_text for marker in _DUPLICATE_INDEX_ERROR_MARKERS)

--- a/apps/ai-service/src/main.py
+++ b/apps/ai-service/src/main.py
@@ -1,13 +1,14 @@
 import logging
-from contextlib import asynccontextmanager
 from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
 from time import perf_counter
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
+
 from .config import settings
-from .db import connect_db, close_db, check_connection
+from .db import check_connection, close_db, connect_db, ensure_collection_indexes
 from .rag import router as rag_router
 from .mcp_server import mcp
 
@@ -17,6 +18,7 @@ logger = logging.getLogger("tessera.ai.timing")
 @asynccontextmanager
 async def lifespan(_app: FastAPI) -> AsyncGenerator[None]:
     await connect_db()
+    await ensure_collection_indexes()
     yield
     await close_db()
 

--- a/apps/ai-service/tests/test_db_indexes.py
+++ b/apps/ai-service/tests/test_db_indexes.py
@@ -1,0 +1,105 @@
+import asyncio
+
+from pymongo.errors import OperationFailure
+
+from src import db
+
+
+class _AsyncIndexes:
+    def __init__(self, indexes):
+        self._indexes = iter(indexes)
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        try:
+            return next(self._indexes)
+        except StopIteration as exc:
+            raise StopAsyncIteration from exc
+
+
+class _FakeCollection:
+    def __init__(self, search_indexes=None, list_error=None, create_index_error=None):
+        self.created_indexes = []
+        self.created_search_indexes = []
+        self.search_indexes = search_indexes or []
+        self.list_error = list_error
+        self.create_index_error = create_index_error
+
+    async def create_index(self, keys, name):
+        if self.create_index_error is not None:
+            raise self.create_index_error
+        self.created_indexes.append((keys, name))
+
+    def list_search_indexes(self):
+        if self.list_error is not None:
+            raise self.list_error
+        return _AsyncIndexes(self.search_indexes)
+
+    async def create_search_index(self, model):
+        self.created_search_indexes.append(model)
+
+
+class _FakeDatabase:
+    def __init__(self, collection):
+        self.collection = collection
+        self.created_collections = []
+
+    async def create_collection(self, name):
+        self.created_collections.append(name)
+
+    def __getitem__(self, name):
+        return self.collection
+
+
+class _FakeClient:
+    def __init__(self, database):
+        self.database = database
+
+    def __getitem__(self, name):
+        return self.database
+
+
+def test_ensure_collection_indexes_creates_standard_and_vector_indexes(monkeypatch):
+    collection = _FakeCollection()
+    database = _FakeDatabase(collection)
+    monkeypatch.setattr(db, "_client", _FakeClient(database))
+
+    asyncio.run(db.ensure_collection_indexes())
+
+    assert database.created_collections == [db.settings.MONGODB_COLLECTION]
+    assert collection.created_indexes == [
+        ([("file_path", db.ASCENDING)], db.FILE_PATH_INDEX_NAME),
+        (
+            [("file_path", db.ASCENDING), ("chunk_index", db.ASCENDING)],
+            db.FILE_PATH_CHUNK_INDEX_NAME,
+        ),
+    ]
+    assert len(collection.created_search_indexes) == 1
+
+
+def test_ensure_collection_indexes_ignores_duplicate_standard_index(monkeypatch):
+    collection = _FakeCollection(
+        create_index_error=OperationFailure("IndexOptionsConflict", code=85)
+    )
+    database = _FakeDatabase(collection)
+    monkeypatch.setattr(db, "_client", _FakeClient(database))
+
+    asyncio.run(db.ensure_collection_indexes())
+
+    assert len(collection.created_search_indexes) == 1
+
+
+def test_has_vector_search_index_returns_true_for_unsupported_search_indexes():
+    collection = _FakeCollection(
+        list_error=OperationFailure("search indexes unsupported", code=40324)
+    )
+
+    assert asyncio.run(db._has_vector_search_index(collection)) is True
+
+
+def test_has_vector_search_index_returns_false_for_transient_failure():
+    collection = _FakeCollection(list_error=OperationFailure("network timeout", code=89))
+
+    assert asyncio.run(db._has_vector_search_index(collection)) is False

--- a/apps/ai-service/tests/test_db_indexes.py
+++ b/apps/ai-service/tests/test_db_indexes.py
@@ -100,6 +100,8 @@ def test_has_vector_search_index_returns_true_for_unsupported_search_indexes():
 
 
 def test_has_vector_search_index_returns_false_for_transient_failure():
-    collection = _FakeCollection(list_error=OperationFailure("network timeout", code=89))
+    collection = _FakeCollection(
+        list_error=OperationFailure("network timeout", code=89)
+    )
 
     assert asyncio.run(db._has_vector_search_index(collection)) is False


### PR DESCRIPTION
Closes #41

## Summary
- Ensures the AI service MongoDB collection exists on startup.
- Adds standard indexes for file path lookup and file/chunk ordering.
- Adds automatic vector search index creation for the `embedding` field.
- Handles MongoDB deployments that do not support search-index APIs without blocking local startup.

## Verification
- python -m compileall apps/ai-service/src
- npm run typecheck
- npm run build
- npm test
- ruff check
- ruff format --check
- Startup-index smoke test passed 10/10