### PR TITLE
feat(ai-service): report DB and model status from /health (#39)

### DIFF
--- a/apps/ai-service/src/config.py
+++ b/apps/ai-service/src/config.py
@@ -5,6 +5,9 @@ class Settings(BaseSettings):
     MONGODB_URI: str = "mongodb://localhost:27017"
     MONGODB_DB_NAME: str = "tessera"
     MONGODB_COLLECTION: str = "code_chunks"
+    # Bound server selection so an unreachable database fails fast (e.g. in the
+    # /health probe) instead of waiting out Motor's 30s default.
+    MONGODB_TIMEOUT_MS: int = 3000
     EMBEDDING_DIMENSIONS: int = 1536
     MCP_SERVER_NAME: str = "tessera-ai"
 

--- a/apps/ai-service/src/db.py
+++ b/apps/ai-service/src/db.py
@@ -1,3 +1,5 @@
+from time import perf_counter
+
 from motor.motor_asyncio import AsyncIOMotorClient, AsyncIOMotorCollection
 from .config import settings
 
@@ -6,7 +8,12 @@ _client: AsyncIOMotorClient | None = None  # type: ignore[type-arg]
 
 async def connect_db() -> None:
     global _client
-    _client = AsyncIOMotorClient(settings.MONGODB_URI)
+    # serverSelectionTimeoutMS keeps the /health probe (and any first query)
+    # fast when the database is unreachable, instead of Motor's 30s default.
+    _client = AsyncIOMotorClient(
+        settings.MONGODB_URI,
+        serverSelectionTimeoutMS=settings.MONGODB_TIMEOUT_MS,
+    )
 
 
 async def close_db() -> None:
@@ -21,3 +28,33 @@ def get_collection() -> AsyncIOMotorCollection:  # type: ignore[type-arg]
         raise RuntimeError("Database not connected. Call connect_db() first.")
     db = _client[settings.MONGODB_DB_NAME]
     return db[settings.MONGODB_COLLECTION]
+
+
+async def check_connection() -> dict[str, object]:
+    """Ping MongoDB and report connectivity statistics for the health check.
+
+    Never raises: a failed or missing connection is reported as
+    ``connected: False`` so the caller can degrade gracefully instead of
+    returning a 500.
+    """
+    status: dict[str, object] = {
+        "connected": False,
+        "database": settings.MONGODB_DB_NAME,
+        "collection": settings.MONGODB_COLLECTION,
+        "latency_ms": None,
+    }
+
+    if _client is None:
+        status["error"] = "Database client not initialized"
+        return status
+
+    start = perf_counter()
+    try:
+        await _client.admin.command("ping")
+    except Exception as exc:
+        status["error"] = str(exc)
+        return status
+
+    status["connected"] = True
+    status["latency_ms"] = round((perf_counter() - start) * 1000, 2)
+    return status

--- a/apps/ai-service/src/main.py
+++ b/apps/ai-service/src/main.py
@@ -5,7 +5,9 @@ from time import perf_counter
 
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
-from .db import connect_db, close_db
+from fastapi.responses import JSONResponse
+from .config import settings
+from .db import connect_db, close_db, check_connection
 from .rag import router as rag_router
 from .mcp_server import mcp
 
@@ -67,5 +69,26 @@ app.mount("/mcp", mcp.sse_app())
 
 
 @app.get("/health")
-async def health_check() -> dict[str, str]:
-    return {"status": "ok"}
+async def health_check() -> JSONResponse:
+    """Report service health: MongoDB connectivity and model/MCP status.
+
+    Returns 200 when the database is reachable and 503 when it is not, so
+    monitoring can act on the status code as well as the JSON body.
+    """
+    database = await check_connection()
+
+    models = {
+        "mcp_server": settings.MCP_SERVER_NAME,
+        "embedding_dimensions": settings.EMBEDDING_DIMENSIONS,
+        # The embedding pipeline is still a placeholder vector (see rag.py);
+        # surfaced here so operators can see it is not a real provider yet.
+        "embedding_provider": "placeholder",
+    }
+
+    healthy = bool(database["connected"])
+    payload = {
+        "status": "ok" if healthy else "degraded",
+        "database": database,
+        "models": models,
+    }
+    return JSONResponse(status_code=200 if healthy else 503, content=payload)

--- a/apps/ai-service/tests/test_health.py
+++ b/apps/ai-service/tests/test_health.py
@@ -1,0 +1,94 @@
+import asyncio
+
+from fastapi.testclient import TestClient
+
+from src import db, main
+from src.main import app
+
+
+class _FakeAdmin:
+    def __init__(self, fail: bool = False) -> None:
+        self._fail = fail
+
+    async def command(self, name: str) -> dict[str, int]:
+        if self._fail:
+            raise RuntimeError("connection refused")
+        return {"ok": 1}
+
+
+class _FakeClient:
+    """Minimal stand-in for AsyncIOMotorClient so tests need no real MongoDB."""
+
+    def __init__(self, fail: bool = False) -> None:
+        self.admin = _FakeAdmin(fail)
+
+
+# --- db.check_connection (the new connectivity probe) ------------------------
+
+
+def test_check_connection_no_client(monkeypatch):
+    monkeypatch.setattr(db, "_client", None)
+    result = asyncio.run(db.check_connection())
+    assert result["connected"] is False
+    assert result["latency_ms"] is None
+    assert "error" in result
+    assert result["database"] == db.settings.MONGODB_DB_NAME
+
+
+def test_check_connection_success(monkeypatch):
+    monkeypatch.setattr(db, "_client", _FakeClient(fail=False))
+    result = asyncio.run(db.check_connection())
+    assert result["connected"] is True
+    assert isinstance(result["latency_ms"], float)
+    assert "error" not in result
+
+
+def test_check_connection_failure(monkeypatch):
+    monkeypatch.setattr(db, "_client", _FakeClient(fail=True))
+    result = asyncio.run(db.check_connection())
+    assert result["connected"] is False
+    assert "connection refused" in result["error"]
+
+
+# --- GET /health (the endpoint behavior issue #39 asks for) ------------------
+
+
+def test_health_returns_200_and_stats_when_db_up(monkeypatch):
+    async def fake_check_connection():
+        return {
+            "connected": True,
+            "database": "tessera",
+            "collection": "code_chunks",
+            "latency_ms": 1.23,
+        }
+
+    monkeypatch.setattr(main, "check_connection", fake_check_connection)
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["database"]["connected"] is True
+    assert body["database"]["latency_ms"] == 1.23
+    assert body["models"]["mcp_server"] == main.settings.MCP_SERVER_NAME
+    assert body["models"]["embedding_dimensions"] == main.settings.EMBEDDING_DIMENSIONS
+
+
+def test_health_returns_503_when_db_down(monkeypatch):
+    async def fake_check_connection():
+        return {
+            "connected": False,
+            "database": "tessera",
+            "collection": "code_chunks",
+            "latency_ms": None,
+            "error": "connection refused",
+        }
+
+    monkeypatch.setattr(main, "check_connection", fake_check_connection)
+    response = TestClient(app).get("/health")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "degraded"
+    assert body["database"]["connected"] is False
+    assert body["database"]["error"] == "connection refused"


### PR DESCRIPTION
## Description

Issue #39 reported that the Python AI service (`apps/ai-service`) had no real health endpoint. Investigation showed the `/health` route already existed but was a scaffold placeholder added in the initial monorepo commit (`1edd56f`), *before* the issue was filed: `health_check()` returned a hard-coded `{"status": "ok"}` and inspected nothing. The route reported the service healthy even when MongoDB was completely unreachable — I confirmed this locally by hitting `/health` with no database running and still getting `200 {"status":"ok"}`.

This PR turns that placeholder into a real health check that reports MongoDB connectivity statistics and model/MCP status, so operators and monitoring can tell at a glance whether the service and its dependencies are actually up.

What changed:
- `apps/ai-service/src/db.py`: add `check_connection()`, which pings MongoDB (`await _client.admin.command("ping")`), times it, and returns `{connected, latency_ms, database, collection, error?}` without raising. Also set a bounded `serverSelectionTimeoutMS` on the client so an unreachable DB fails fast instead of hanging on Motor's 30s default.
- `apps/ai-service/src/config.py`: add `MONGODB_TIMEOUT_MS` (default `3000`) to drive that timeout.
- `apps/ai-service/src/main.py`: `health_check()` now returns a `database` block (connectivity + latency) and a `models` block (`MCP_SERVER_NAME`, `EMBEDDING_DIMENSIONS`, `embedding_provider`), returning HTTP `200` when healthy and `503` when the database is unreachable.
- `apps/ai-service/tests/test_health.py`: new pytest suite (5 tests) covering the probe and both endpoint paths with a fake Motor client, so the suite needs no live MongoDB.

One open design question for you: I return `503` when the database is unreachable so monitoring can act on the status code as well as the body. If you'd prefer the endpoint always return `200` with a status field instead, I'm happy to switch.

Fixes #39

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] Existing/new tests pass — `python -m pytest tests/` → **5 passed**
- [x] Python lint/format clean — `ruff check src/ tests/` and `ruff format --check src/ tests/` → clean (the `apps/ai-service` package lints with `ruff`/`pytest`; these Python-only changes don't touch the TS workspaces, and the repo's **CI Pipeline (Lint, Typecheck, Test, Build)** check is green on this PR)

### Manual Verification
- [x] With MongoDB **down**: `GET /health` → `503 degraded` in ~3s (was 30s before the timeout fix)
- [x] With MongoDB **up**: `GET /health` → `200`, `database.connected: true` with a `latency_ms` figure

**Before** (placeholder route, MongoDB down):
```
HTTP/1.1 200 OK
{"status":"ok"}
```

**After** (this PR, MongoDB down):
```
HTTP/1.1 503 Service Unavailable
{
  "status": "degraded",
  "database": { "connected": false, "database": "tessera", "collection": "code_chunks",
                "latency_ms": null, "error": "localhost:27017: [Errno 61] Connection refused ..." },
  "models": { "mcp_server": "tessera-ai", "embedding_dimensions": 1536, "embedding_provider": "placeholder" }
}
```

## Checklist
- [x] My commits are **signed off** using `git commit -s` (`Signed-off-by: BRIAN BAZURTO <...>`).
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. (No docs change needed — the endpoint is self-describing via its JSON payload; happy to add a note to the service README if you'd like one.)
- [x] My changes generate no new warnings or console errors.
