### PR TITLE
feat: add loading spinner and download button to explorer panel

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -6,6 +6,7 @@ import {
   createDefaultParticipant,
 } from "./hooks/useCollaboration.js";
 import type { SyncConnectionConfig, SupportedLanguage, ExecutionResult } from "@tessera/shared-types";
+import { downloadTextFile } from "./utils/downloadUtils.js";
 
 const SYNC_SERVER_URL = "http://localhost:4000";
 const DEFAULT_ROOM = "default-room";
@@ -61,15 +62,7 @@ export function App() {
 
   const handleDownload = () => {
     if (!ytext) return;
-    const content = ytext.toString();
-    const fileName = FILE_NAMES[language];
-    const blob = new Blob([content], { type: "text/plain" });
-    const url = URL.createObjectURL(blob);
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = fileName;
-    a.click();
-    URL.revokeObjectURL(url);
+    downloadTextFile(ytext.toString(), FILE_NAMES[language]);
   };
   return (
     <div className="flex h-screen flex-col bg-[var(--color-bg)]">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -59,6 +59,18 @@ export function App() {
     });
   };
 
+  const handleDownload = () => {
+    if (!ytext) return;
+    const content = ytext.toString();
+    const fileName = FILE_NAMES[language];
+    const blob = new Blob([content], { type: "text/plain" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = fileName;
+    a.click();
+    URL.revokeObjectURL(url);
+  };
   return (
     <div className="flex h-screen flex-col bg-[var(--color-bg)]">
       {/* Header */}
@@ -142,6 +154,17 @@ export function App() {
             <div className="rounded px-2 py-1 text-sm font-medium text-tessera-400 bg-tessera-500/10 border border-tessera-500/20">
               📄 {FILE_NAMES[language]}
             </div>
+            <button
+              onClick={handleDownload}
+              disabled={!ytext}
+              className="mt-2 flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-slate-400 hover:text-white hover:bg-[var(--color-bg)] rounded transition w-full"
+              title="Download file"
+            >
+              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+              </svg>
+              Download
+            </button>
           </div>
         </aside>
 
@@ -150,7 +173,11 @@ export function App() {
           {ytext && awareness ? (
             <CollaborativeEditor ytext={ytext} awareness={awareness} language={language} />
           ) : (
-            <div className="flex h-full items-center justify-center text-slate-500 font-medium bg-[var(--color-bg)]">
+            <div className="flex h-full flex-col items-center justify-center gap-3 text-slate-500 font-medium bg-[var(--color-bg)]">
+              <svg className="animate-spin h-8 w-8 text-tessera-400" fill="none" viewBox="0 0 24 24">
+                <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              </svg>
               Connecting to collaboration server…
             </div>
           )}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -122,6 +122,16 @@ export function App() {
               </>
             )}
           </button>
+          {/* Download Button */}
+          <button
+            onClick={handleDownload}
+            disabled={!ytext}
+            className="flex items-center justify-center p-1.5 text-slate-400 hover:text-white hover:bg-[var(--color-bg)] rounded transition"
+            title={`Download ${FILE_NAMES[language]}`}>
+            <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
+            </svg>
+          </button>
 
           <button
             type="button"
@@ -154,17 +164,6 @@ export function App() {
             <div className="rounded px-2 py-1 text-sm font-medium text-tessera-400 bg-tessera-500/10 border border-tessera-500/20">
               📄 {FILE_NAMES[language]}
             </div>
-            <button
-              onClick={handleDownload}
-              disabled={!ytext}
-              className="mt-2 flex items-center gap-1.5 px-2 py-1 text-xs font-medium text-slate-400 hover:text-white hover:bg-[var(--color-bg)] rounded transition w-full"
-              title="Download file"
-            >
-              <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
-              </svg>
-              Download
-            </button>
           </div>
         </aside>
 

--- a/apps/web/src/utils/downloadUtils.ts
+++ b/apps/web/src/utils/downloadUtils.ts
@@ -1,0 +1,15 @@
+/**
+ * Downloads the given text content as a file to the user's disk.
+ *
+ * @param content - The text content to download
+ * @param fileName - The name of the file to save
+ */
+export function downloadTextFile(content: string, fileName: string): void {
+  const blob = new Blob([content], { type: "text/plain" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  a.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
## Description
Added an animated CSS/SVG loading spinner to the 'Connecting to collaboration 
server...' view for better user feedback during slow connection initiations. 
Also added a download icon button in the explorer panel that exports the editor 
text buffer as a local file (e.g. main.ts or main.py), allowing developers to 
save local backup snapshots of their sandboxed files.

Fixes #28
Fixes #29

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Existing/new tests pass (`npm run test`)

### Manual Verification
- [x] Verified local dev environment works (`npm run dev`)
- [x] Tested functionality in the browser / execution engine

## Checklist
- [x] My commits are **signed off** using `git commit -s`
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.