### PR TITLE
fix: Enabled ctrl enter for code execution #Issue25

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -49,6 +49,29 @@ export function App() {
     };
   }, [socket]);
 
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      let isMac = false;
+      if ("userAgentData" in navigator && navigator.userAgentData) {
+        isMac = (navigator.userAgentData as any).platform.toLowerCase() === "macos";
+      } else {
+        isMac = navigator.userAgent.toLowerCase().includes("mac");
+      }
+
+      const isExecutionShortcut = isMac ? event.metaKey : event.ctrlKey;
+
+      if (isExecutionShortcut && event.key === "Enter") {
+        event.preventDefault();
+        if (!isRunning && connected) {
+          handleRunCode();
+        }
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [socket, ytext, isRunning, connected]);
+
   const handleRunCode = () => {
     if (!socket || !ytext || isRunning) return;
     setIsRunning(true);
@@ -88,6 +111,13 @@ export function App() {
           <button
             onClick={handleRunCode}
             disabled={!connected || isRunning}
+            title={`Run code (${
+              "userAgentData" in navigator && (navigator.userAgentData as any).platform.toLowerCase() === "macos"
+                ? "Cmd"
+                : navigator.userAgent.toLowerCase().includes("mac")
+                ? "Cmd"
+                : "Ctrl"
+            }+Enter)`}
             className={`flex items-center gap-1.5 px-3 py-1 text-sm font-semibold rounded transition shadow-sm ${
               isRunning
                 ? "bg-slate-700 text-slate-400 cursor-not-allowed"

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -57,9 +57,7 @@ export function App() {
       } else {
         isMac = navigator.userAgent.toLowerCase().includes("mac");
       }
-
       const isExecutionShortcut = isMac ? event.metaKey : event.ctrlKey;
-
       if (isExecutionShortcut && event.key === "Enter") {
         event.preventDefault();
         if (!isRunning && connected) {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -5,6 +5,7 @@ import {
   useCollaboration,
   createDefaultParticipant,
 } from "./hooks/useCollaboration.js";
+import { isMacOS, getExecutionShortcutText } from "./utils/platformDetection.js";
 import type { SyncConnectionConfig, SupportedLanguage, ExecutionResult } from "@tessera/shared-types";
 
 const SYNC_SERVER_URL = "http://localhost:4000";
@@ -51,13 +52,7 @@ export function App() {
 
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
-      let isMac = false;
-      if ("userAgentData" in navigator && navigator.userAgentData) {
-        isMac = (navigator.userAgentData as any).platform.toLowerCase() === "macos";
-      } else {
-        isMac = navigator.userAgent.toLowerCase().includes("mac");
-      }
-      const isExecutionShortcut = isMac ? event.metaKey : event.ctrlKey;
+      const isExecutionShortcut = isMacOS() ? event.metaKey : event.ctrlKey;
       if (isExecutionShortcut && event.key === "Enter") {
         event.preventDefault();
         if (!isRunning && connected) {
@@ -109,13 +104,7 @@ export function App() {
           <button
             onClick={handleRunCode}
             disabled={!connected || isRunning}
-            title={`Run code (${
-              "userAgentData" in navigator && (navigator.userAgentData as any).platform.toLowerCase() === "macos"
-                ? "Cmd"
-                : navigator.userAgent.toLowerCase().includes("mac")
-                ? "Cmd"
-                : "Ctrl"
-            }+Enter)`}
+            title={`Run code (${getExecutionShortcutText()})`}
             className={`flex items-center gap-1.5 px-3 py-1 text-sm font-semibold rounded transition shadow-sm ${
               isRunning
                 ? "bg-slate-700 text-slate-400 cursor-not-allowed"

--- a/apps/web/src/utils/platformDetection.ts
+++ b/apps/web/src/utils/platformDetection.ts
@@ -1,0 +1,17 @@
+/**
+ * Detects if the current OS is macOS
+ * Uses the modern userAgentData API if available, falls back to userAgent string
+ */
+export function isMacOS(): boolean {
+  if ("userAgentData" in navigator && navigator.userAgentData) {
+    return (navigator.userAgentData as any).platform.toLowerCase() === "macos";
+  }
+  return navigator.userAgent.toLowerCase().includes("mac");
+}
+
+/**
+ * Gets the platform-specific keyboard shortcut display text
+ */
+export function getExecutionShortcutText(): string {
+  return isMacOS() ? "Cmd+Enter" : "Ctrl+Enter";
+}


### PR DESCRIPTION
Enable keyboard-only workflow by listening for Ctrl+Enter (Windows/Linux) and Cmd+Enter (macOS) to trigger code execution. Updated platform detection to use modern userAgentData API with fallback to userAgent string, replacing deprecated navigator.platform.

Changes:

- Added keyboard event listener for execution shortcut
- Updated Run button with dynamic tooltip showing platform-specific shortcut
- Replaced deprecated platform detection with modern APIs