### PR TITLE
feat(editor): add sidebar toggle for Monaco minimap visibility

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -22,6 +22,7 @@ export function App() {
   const [isRunning, setIsRunning] = useState(false);
   const [isAiPanelOpen, setIsAiPanelOpen] = useState(false);
   const [output, setOutput] = useState<ExecutionResult | null>(null);
+  const [showMinimap, setShowMinimap] = useState(true);
 
   const config = useMemo<SyncConnectionConfig>(
     () => ({
@@ -134,13 +135,36 @@ export function App() {
       {/* Main content */}
       <div className="flex flex-1 overflow-hidden">
         {/* Sidebar */}
-        <aside className="w-56 shrink-0 border-r border-[var(--color-border)] bg-[var(--color-surface)] p-3">
-          <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
-            Explorer
-          </p>
-          <div className="mt-3 space-y-1">
-            <div className="rounded px-2 py-1 text-sm font-medium text-tessera-400 bg-tessera-500/10 border border-tessera-500/20">
-              📄 {FILE_NAMES[language]}
+        <aside className="w-56 shrink-0 border-r border-[var(--color-border)] bg-[var(--color-surface)] p-3 flex flex-col justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+              Explorer
+            </p>
+            <div className="mt-3 space-y-1">
+              <div className="rounded px-2 py-1 text-sm font-medium text-tessera-400 bg-tessera-500/10 border border-tessera-500/20">
+                📄 {FILE_NAMES[language]}
+              </div>
+            </div>
+          </div>
+
+          <div className="border-t border-[var(--color-border)] pt-4">
+            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">
+              Editor Settings
+            </p>
+            <div className="flex items-center justify-between">
+              <label htmlFor="minimap-toggle" className="text-xs font-medium text-slate-300 cursor-pointer select-none">
+                Show Minimap
+              </label>
+              <div className="relative inline-flex items-center">
+                <input
+                  type="checkbox"
+                  id="minimap-toggle"
+                  checked={showMinimap}
+                  onChange={(e) => setShowMinimap(e.target.checked)}
+                  className="sr-only peer"
+                />
+                <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600 cursor-pointer"></div>
+              </div>
             </div>
           </div>
         </aside>
@@ -148,7 +172,7 @@ export function App() {
         {/* Editor */}
         <main className="flex-1 overflow-hidden">
           {ytext && awareness ? (
-            <CollaborativeEditor ytext={ytext} awareness={awareness} language={language} />
+            <CollaborativeEditor ytext={ytext} awareness={awareness} language={language} showMinimap={showMinimap} />
           ) : (
             <div className="flex h-full items-center justify-center text-slate-500 font-medium bg-[var(--color-bg)]">
               Connecting to collaboration server…

--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -10,6 +10,7 @@ interface CollaborativeEditorProps {
   readonly ytext: Y.Text;
   readonly awareness: Awareness;
   readonly language?: SupportedLanguage;
+  readonly showMinimap?: boolean;
 }
 
 const LANGUAGE_MAP: Record<SupportedLanguage, string> = {
@@ -22,6 +23,7 @@ export function CollaborativeEditor({
   ytext,
   awareness,
   language = "typescript",
+  showMinimap = true,
 }: CollaborativeEditorProps) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const bindingRef = useRef<MonacoBinding | null>(null);
@@ -50,6 +52,14 @@ export function CollaborativeEditor({
     };
   }, []);
 
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.updateOptions({
+        minimap: { enabled: showMinimap },
+      });
+    }
+  }, [showMinimap]);
+
   return (
     <Editor
       height="100%"
@@ -57,7 +67,7 @@ export function CollaborativeEditor({
       theme="vs-dark"
       onMount={handleEditorMount}
       options={{
-        minimap: { enabled: false },
+        minimap: { enabled: showMinimap },
         fontSize: 14,
         fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
         lineNumbers: "on",


### PR DESCRIPTION
Adds a controlled `showMinimap` toggle in the sidebar under a new "Editor Settings" section. State is managed in `App.tsx` and passed as a prop to `CollaborativeEditor`, where it's bound to Monaco's `minimap.enabled` option via `editor.updateOptions` inside a `useEffect`. Minimap is enabled by default and can be toggled off instantly without remounting the editor.

Fixes #24

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes — 10 tasks successful in 2.797s
- [x] `npm run build` passes — 7 tasks successful
- [x] Existing/new tests pass — 4/4 passed in `aiService.test.ts`

### Manual Verification
- [x] Verified local dev environment works (`npm run dev`)
- [x] Tested toggle in browser — minimap responds instantly in both states

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Screenshot

toggle on
<img width="2839" height="1390" alt="toggleon" src="https://github.com/user-attachments/assets/60357761-fbc0-49e7-80f1-5282bf212919" />

toggle off
<img width="2825" height="1382" alt="toggleoff" src="https://github.com/user-attachments/assets/1827525c-abef-45ba-a885-4c816f165c36" />


