### PR TITLE
feat(editor): add A+/A- font size controls to sidebar

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -25,6 +25,7 @@ export function App() {
   const [isAiPanelOpen, setIsAiPanelOpen] = useState(false);
   const [output, setOutput] = useState<ExecutionResult | null>(null);
   const [showMinimap, setShowMinimap] = useState(true);
+  const [fontSize, setFontSize] = useState(14);
 
   const config = useMemo<SyncConnectionConfig>(
     () => ({
@@ -168,19 +169,44 @@ export function App() {
             <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">
               Editor Settings
             </p>
-            <div className="flex items-center justify-between">
-              <label htmlFor="minimap-toggle" className="text-xs font-medium text-slate-300 cursor-pointer select-none">
-                Show Minimap
-              </label>
-              <div className="relative inline-flex items-center">
-                <input
-                  type="checkbox"
-                  id="minimap-toggle"
-                  checked={showMinimap}
-                  onChange={(e) => setShowMinimap(e.target.checked)}
-                  className="sr-only peer"
-                />
-                <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600 cursor-pointer"></div>
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <label htmlFor="minimap-toggle" className="text-xs font-medium text-slate-300 cursor-pointer select-none">
+                  Show Minimap
+                </label>
+                <div className="relative inline-flex items-center">
+                  <input
+                    type="checkbox"
+                    id="minimap-toggle"
+                    checked={showMinimap}
+                    onChange={(e) => setShowMinimap(e.target.checked)}
+                    className="sr-only peer"
+                  />
+                  <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600 cursor-pointer"></div>
+                </div>
+              </div>
+
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-medium text-slate-300">Font Size</span>
+                <div className="flex items-center gap-1.5">
+                  <button
+                    onClick={() => setFontSize((prev) => Math.max(10, prev - 1))}
+                    disabled={fontSize <= 10}
+                    className="w-6 h-6 flex items-center justify-center rounded border border-[var(--color-border)] bg-[var(--color-bg)] text-xs text-slate-300 hover:text-white hover:border-tessera-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-[var(--color-border)] disabled:hover:text-slate-300 select-none transition-all active:scale-95"
+                  >
+                    A-
+                  </button>
+                  <span className="text-xs font-mono font-medium text-slate-200 min-w-[28px] text-center">
+                    {fontSize}px
+                  </span>
+                  <button
+                    onClick={() => setFontSize((prev) => Math.min(24, prev + 1))}
+                    disabled={fontSize >= 24}
+                    className="w-6 h-6 flex items-center justify-center rounded border border-[var(--color-border)] bg-[var(--color-bg)] text-xs text-slate-300 hover:text-white hover:border-tessera-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-[var(--color-border)] disabled:hover:text-slate-300 select-none transition-all active:scale-95"
+                  >
+                    A+
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -189,7 +215,13 @@ export function App() {
         {/* Editor */}
         <main className="flex-1 overflow-hidden">
           {ytext && awareness ? (
-            <CollaborativeEditor ytext={ytext} awareness={awareness} language={language} showMinimap={showMinimap} />
+            <CollaborativeEditor
+              ytext={ytext}
+              awareness={awareness}
+              language={language}
+              showMinimap={showMinimap}
+              fontSize={fontSize}
+            />
           ) : (
             <div className="flex h-full flex-col items-center justify-center gap-3 text-slate-500 font-medium bg-[var(--color-bg)]">
               <svg className="animate-spin h-8 w-8 text-tessera-400" fill="none" viewBox="0 0 24 24">

--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -11,6 +11,7 @@ interface CollaborativeEditorProps {
   readonly awareness: Awareness;
   readonly language?: SupportedLanguage;
   readonly showMinimap?: boolean;
+  readonly fontSize?: number;
 }
 
 const LANGUAGE_MAP: Record<SupportedLanguage, string> = {
@@ -25,6 +26,7 @@ export function CollaborativeEditor({
   awareness,
   language = "typescript",
   showMinimap = true,
+  fontSize = 14,
 }: CollaborativeEditorProps) {
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const bindingRef = useRef<MonacoBinding | null>(null);
@@ -61,6 +63,12 @@ export function CollaborativeEditor({
     }
   }, [showMinimap]);
 
+  useEffect(() => {
+    if (editorRef.current) {
+      editorRef.current.updateOptions({ fontSize });
+    }
+  }, [fontSize]);
+
   return (
     <Editor
       height="100%"
@@ -69,7 +77,7 @@ export function CollaborativeEditor({
       onMount={handleEditorMount}
       options={{
         minimap: { enabled: showMinimap },
-        fontSize: 14,
+        fontSize,
         fontFamily: "'JetBrains Mono', 'Fira Code', monospace",
         lineNumbers: "on",
         renderWhitespace: "selection",


### PR DESCRIPTION
Adds A+ and A- font size control buttons to the sidebar under a new "Editor Settings" section. Font size state is managed in `App.tsx` and passed as a prop to `CollaborativeEditor`, where it is bound to Monaco's `fontSize` option via `editor.updateOptions` inside a `useEffect`. Font size is clamped between 10px and 24px — buttons are disabled at their respective boundaries.

Fixes #26

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run lint` passes — 10 tasks successful in 671ms
- [x] `npm run typecheck` passes — 10 tasks successful in 2.797s
- [x] `npm run build` passes — 7 tasks successful
- [x] Existing/new tests pass — 4/4 passed in `aiService.test.ts`

### Manual Verification
- [x] Verified local dev environment works (`npm run dev`)
- [x] Tested A+ and A- buttons in browser — font size updates instantly in Monaco
- [x] Verified A- disables at 10px and A+ disables at 24px

## Checklist
- [x] My commits are signed off using `git commit -s`
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Screenshots
14px
<img width="1440" height="720" alt="Screenshot 2026-06-09 at 12 17 38 PM" src="https://github.com/user-attachments/assets/37c08369-b74e-4f5e-9aaf-227668c014ba" />

18px
<img width="1440" height="721" alt="Screenshot 2026-06-09 at 12 17 53 PM" src="https://github.com/user-attachments/assets/ba3851a7-8761-4d1c-a1a7-40b035415d9d" />

10px
<img width="1440" height="720" alt="Screenshot 2026-06-09 at 12 18 06 PM" src="https://github.com/user-attachments/assets/31a6e662-a01d-4978-b9f9-50aeb05cea93" />
