### PR TITLE
feat(collaboration): add clearLocalDoc() to TesseraSocketProvider

### DIFF
--- a/packages/collaboration/src/provider.ts
+++ b/packages/collaboration/src/provider.ts
@@ -42,6 +42,20 @@ export class TesseraSocketProvider {
     this.socket.off("awareness-update", this.handleAwarenessRemoteUpdate);
   }
 
+  /**
+ * Deletes all content from the shared Monaco text in a single atomic
+ * Yjs transaction, propagating the deletion to all synced clients via
+ * the existing sync-update socket pipeline.
+ */
+  clearLocalDoc(): void {
+    if (this.destroyed) return;
+    const ytext = this.ydoc.getText("monaco");
+    if (ytext.length === 0) return;
+    this.ydoc.transact(() => {
+      ytext.delete(0, ytext.length);
+    });
+  }
+
   private sendSyncStep1(): void {
     const stateVector = Y.encodeStateVector(this.ydoc);
     this.socket.emit("sync-step-1", stateVector);


### PR DESCRIPTION
## Description

Adds a `clearLocalDoc()` utility method to `TesseraSocketProvider` in `packages/collaboration/src/provider.ts`.

The method atomically deletes all content from the shared `"monaco"` `Y.Text` inside a single `ydoc.transact()` call, producing one clean deletion block that propagates to all synced clients via the existing `sync-update` socket pipeline - no new socket events required.

Fixes #33

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

The method hooks into the existing `handleDocUpdate → socket.emit("sync-update")` pipeline. Any local transact call with origin `null` (i.e. not originating from the socket) is automatically emitted and broadcast by the sync-server to all room clients.

### Automated Verification
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Existing/new tests pass (`npm run test`)

### Manual Verification
- [ ] Verified local dev environment works (`npm run dev`)
- [ ] Tested functionality in the browser / execution engine

## Checklist
- [x] My commits are **signed off** using `git commit -s` (e.g. `Signed-off-by: Name <email>`).
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.