### PR TITLE
fix(execution-engine): demultiplex Docker logs to fix unknown symbols in output (#46)

### DIFF
--- a/apps/execution-engine/package.json
+++ b/apps/execution-engine/package.json
@@ -8,6 +8,7 @@
     "dev": "tsx watch src/worker.ts",
     "start": "node dist/worker.js",
     "typecheck": "tsc --noEmit",
+    "test": "vitest run --passWithNoTests",
     "clean": "rm -rf dist",
     "lint": "echo 'lint not configured yet'"
   },

--- a/apps/execution-engine/src/sandbox.test.ts
+++ b/apps/execution-engine/src/sandbox.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+import { demuxDockerStream } from "./sandbox.js";
+
+const STREAM_STDOUT = 1;
+const STREAM_STDERR = 2;
+
+/** Build a single Docker multiplexed-stream frame (8-byte header + payload). */
+function frame(streamType: number, text: string): Buffer {
+  const payload = Buffer.from(text, "utf-8");
+  const header = Buffer.alloc(8);
+  header[0] = streamType;
+  header.writeUInt32BE(payload.length, 4);
+  return Buffer.concat([header, payload]);
+}
+
+describe("demuxDockerStream", () => {
+  it("returns empty streams for an empty buffer", () => {
+    expect(demuxDockerStream(Buffer.alloc(0))).toEqual({ stdout: "", stderr: "" });
+  });
+
+  it("strips the 8-byte header that the old raw read leaked into the output", () => {
+    const framed = frame(STREAM_STDOUT, "Hello World\n");
+
+    // Reproduction of the bug: reading the multiplexed buffer straight as UTF-8
+    // (the previous behavior) leaks the binary header, so it is NOT clean output.
+    expect(framed.toString("utf-8")).not.toBe("Hello World\n");
+    expect(framed.toString("utf-8").charCodeAt(0)).toBe(STREAM_STDOUT);
+
+    // The fix: clean stdout with no leading control bytes.
+    expect(demuxDockerStream(framed)).toEqual({ stdout: "Hello World\n", stderr: "" });
+  });
+
+  it("separates stdout and stderr frames", () => {
+    const buffer = Buffer.concat([
+      frame(STREAM_STDOUT, "out line 1\n"),
+      frame(STREAM_STDERR, "err line\n"),
+      frame(STREAM_STDOUT, "out line 2\n"),
+    ]);
+
+    expect(demuxDockerStream(buffer)).toEqual({
+      stdout: "out line 1\nout line 2\n",
+      stderr: "err line\n",
+    });
+  });
+
+  it("concatenates multiple frames of the same stream in order", () => {
+    const buffer = Buffer.concat([
+      frame(STREAM_STDOUT, "a"),
+      frame(STREAM_STDOUT, "b"),
+      frame(STREAM_STDOUT, "c"),
+    ]);
+
+    expect(demuxDockerStream(buffer).stdout).toBe("abc");
+  });
+
+  it("preserves multi-byte UTF-8 payloads split correctly by byte length", () => {
+    const text = "café — 日本語\n";
+    expect(demuxDockerStream(frame(STREAM_STDOUT, text)).stdout).toBe(text);
+  });
+
+  it("falls back to stdout for a non-multiplexed (raw/TTY) buffer", () => {
+    // A raw TTY stream has no frame headers; the first byte is real content,
+    // not a 0-2 stream type. It must be returned intact as stdout, not dropped.
+    const raw = Buffer.from("plain tty output\n", "utf-8");
+    expect(demuxDockerStream(raw)).toEqual({ stdout: "plain tty output\n", stderr: "" });
+  });
+
+  it("does not drop a truncated trailing frame", () => {
+    const truncated = Buffer.concat([
+      frame(STREAM_STDOUT, "complete\n"),
+      Buffer.from([STREAM_STDOUT, 0, 0]), // partial header, < 8 bytes
+    ]);
+
+    const { stdout } = demuxDockerStream(truncated);
+    expect(stdout.startsWith("complete\n")).toBe(true);
+  });
+});

--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -3,6 +3,66 @@ import type { ExecutionTask, ExecutionResult, SandboxConfig, SupportedLanguage }
 
 const docker = new Dockerode({ socketPath: "/var/run/docker.sock" });
 
+/** Cleanly separated output streams parsed from a Docker log buffer. */
+export interface DemuxedStreams {
+  stdout: string;
+  stderr: string;
+}
+
+// Docker multiplexes stdout/stderr into a single stream when a container runs
+// without a TTY (`Tty: false`, our default). Every payload chunk is prefixed with
+// an 8-byte header: byte 0 is the stream type (0 = stdin, 1 = stdout, 2 = stderr),
+// bytes 1-3 are zero padding, and bytes 4-7 are the payload length as a big-endian
+// uint32. See https://docs.docker.com/engine/api/v1.43/#tag/Container/operation/ContainerAttach
+const STREAM_HEADER_SIZE = 8;
+const STREAM_TYPE_STDERR = 2;
+
+/**
+ * Parse a multiplexed Docker log buffer into separate `stdout` and `stderr`
+ * strings, stripping the 8-byte frame headers. If the buffer is not multiplexed
+ * (for example a raw stream from a TTY-allocated container), the bytes are
+ * returned as `stdout` rather than being corrupted or dropped.
+ */
+export function demuxDockerStream(buffer: Buffer): DemuxedStreams {
+  const stdoutChunks: Buffer[] = [];
+  const stderrChunks: Buffer[] = [];
+  let offset = 0;
+
+  while (offset + STREAM_HEADER_SIZE <= buffer.length) {
+    const streamType = buffer[offset];
+    const payloadLength = buffer.readUInt32BE(offset + 4);
+    const payloadStart = offset + STREAM_HEADER_SIZE;
+    const payloadEnd = payloadStart + payloadLength;
+
+    // A valid frame has a known stream type (0-2) and a length that stays within
+    // the buffer. Anything else means this isn't a multiplexed stream, so treat
+    // the remaining bytes as stdout instead of emitting garbage.
+    if (streamType === undefined || streamType > STREAM_TYPE_STDERR || payloadEnd > buffer.length) {
+      stdoutChunks.push(buffer.subarray(offset));
+      return joinStreams(stdoutChunks, stderrChunks);
+    }
+
+    const payload = buffer.subarray(payloadStart, payloadEnd);
+    (streamType === STREAM_TYPE_STDERR ? stderrChunks : stdoutChunks).push(payload);
+    offset = payloadEnd;
+  }
+
+  // Trailing bytes too short to form a header shouldn't occur for a well-formed
+  // stream, but keep them (as stdout) rather than silently dropping output.
+  if (offset < buffer.length) {
+    stdoutChunks.push(buffer.subarray(offset));
+  }
+
+  return joinStreams(stdoutChunks, stderrChunks);
+}
+
+function joinStreams(stdoutChunks: Buffer[], stderrChunks: Buffer[]): DemuxedStreams {
+  return {
+    stdout: Buffer.concat(stdoutChunks).toString("utf-8"),
+    stderr: Buffer.concat(stderrChunks).toString("utf-8"),
+  };
+}
+
 const LANGUAGE_IMAGES: Record<SupportedLanguage, string> = {
   typescript: "node:20-slim",
   python: "python:3.12-slim",
@@ -89,7 +149,8 @@ export async function executeInSandbox(task: ExecutionTask): Promise<ExecutionRe
     }
 
     const logs = await container.logs({ stdout: true, stderr: true, follow: false });
-    const logOutput = typeof logs === "string" ? logs : logs.toString("utf-8");
+    const logBuffer = Buffer.isBuffer(logs) ? logs : Buffer.from(logs as unknown as string, "utf-8");
+    const { stdout, stderr } = demuxDockerStream(logBuffer);
 
     const inspectInfo = await container.inspect();
     const exitCode = inspectInfo.State.ExitCode as number;
@@ -97,8 +158,8 @@ export async function executeInSandbox(task: ExecutionTask): Promise<ExecutionRe
     return {
       taskId: task.id,
       status: exitCode === 0 ? "completed" : "failed",
-      stdout: logOutput,
-      stderr: "",
+      stdout,
+      stderr,
       exitCode,
       durationMs: performance.now() - startTime,
     };


### PR DESCRIPTION
## Description

Issue #46 reported that the execution output panel showed unknown replacement symbols (boxed question marks) at the start of each output line. I traced it to `apps/execution-engine/src/sandbox.ts`: containers run without a TTY (`Tty: false`), so `container.logs({ follow: false })` returns Docker's **multiplexed** stream — every payload chunk is prefixed with an 8-byte frame header (`[stream_type, 0, 0, 0, size_be_u32]`). The code read that buffer straight as UTF-8 (`logs.toString("utf-8")`), so the binary header bytes leaked into the displayed output, and `stderr` was hard-coded to `""`, so standard error was never separated from standard output.

This PR adds a `demuxDockerStream(buffer)` helper that walks the frames, strips the 8-byte headers, and routes each payload to `stdout` or `stderr` by its stream-type byte. If a non-multiplexed (raw/TTY) buffer is ever passed, it falls back to returning the bytes as `stdout` so output is never corrupted or dropped. `executeInSandbox` now returns cleanly separated `stdout` and `stderr` in the `ExecutionResult` (the type already has both fields).

Fixes #46

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Automated Verification
- [x] Existing/new tests pass — added `apps/execution-engine/src/sandbox.test.ts` (vitest, 7 tests). `npm run test` → execution-engine **7/7** and web **4/4** pass.
- [x] `npm run typecheck` passes (repo-wide, 10/10)
- [x] `npm run build` passes (repo-wide, 7/7)
- [x] Wired up the package `test` script (`vitest run`), which was previously a placeholder/absent for this workspace

### Manual Verification
The demuxer is covered by unit tests built from synthetic Docker frames, so it needs no live Docker daemon in CI. Byte-level before/after for a multiplexed `stdout` frame carrying `Hello World\n`:

```
Before (raw buffer.toString("utf-8")): leading \x01 stream byte + \x00\x00\x00\x0c header leak in front of "Hello World"
After  (demuxDockerStream):            { stdout: "Hello World\n", stderr: "" }   // header stripped, stderr separated
```

(A full end-to-end render in the browser output panel needs a running Docker daemon, which CI doesn't provide; the unit tests assert the exact byte-level behavior the issue describes.)

## Checklist
- [x] My commits are **signed off** using `git commit -s`.
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. (No user-facing docs affected — the change is internal to the execution engine.)
- [x] My changes generate no new warnings or console errors.
