### PR TITLE
feat(web): add C++ IntelliSense provider

### DIFF
--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -5,6 +5,7 @@ import type * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness";
 import type { editor } from "monaco-editor";
 import type { SupportedLanguage } from "@tessera/shared-types";
+import { registerEditorIntelliSense } from "../intellisense/index.js";
 
 interface CollaborativeEditorProps {
   readonly ytext: Y.Text;
@@ -27,8 +28,9 @@ export function CollaborativeEditor({
   const bindingRef = useRef<MonacoBinding | null>(null);
 
   const handleEditorMount: OnMount = useCallback(
-    (mountedEditor) => {
+    (mountedEditor, monaco) => {
       editorRef.current = mountedEditor;
+      registerEditorIntelliSense(monaco);
 
       const model = mountedEditor.getModel();
       if (!model) return;

--- a/apps/web/src/intellisense/cpp.ts
+++ b/apps/web/src/intellisense/cpp.ts
@@ -86,11 +86,48 @@ function createRange(
   );
 }
 
+function createHashAwareRange(
+  monaco: typeof Monaco,
+  model: Monaco.editor.ITextModel,
+  position: Monaco.Position,
+) {
+  const word = model.getWordUntilPosition(position);
+  const line = model.getLineContent(position.lineNumber);
+  const startColumn =
+    word.startColumn > 1 && line[word.startColumn - 2] === "#"
+      ? word.startColumn - 1
+      : word.startColumn;
+
+  return new monaco.Range(
+    position.lineNumber,
+    startColumn,
+    position.lineNumber,
+    word.endColumn,
+  );
+}
+
+function hasStdNamespacePrefix(
+  model: Monaco.editor.ITextModel,
+  position: Monaco.Position,
+  range: Monaco.IRange,
+) {
+  const line = model.getLineContent(position.lineNumber);
+  const prefix = line.slice(0, range.startColumn - 1);
+
+  return prefix.endsWith("std::");
+}
+
 export function registerCppIntelliSense(monaco: typeof Monaco): Monaco.IDisposable {
   return monaco.languages.registerCompletionItemProvider("cpp", {
     triggerCharacters: ["#", ".", ":", "<"],
     provideCompletionItems(model, position) {
       const range = createRange(monaco, model, position);
+      const includeRange = createHashAwareRange(monaco, model, position);
+      const shouldInsertStlNameOnly = hasStdNamespacePrefix(
+        model,
+        position,
+        range,
+      );
 
       const keywordSuggestions = C_CPP_KEYWORDS.map((keyword) => ({
         label: keyword,
@@ -102,7 +139,9 @@ export function registerCppIntelliSense(monaco: typeof Monaco): Monaco.IDisposab
       const stlSuggestions = STL_SUGGESTIONS.map((symbol) => ({
         label: symbol,
         kind: monaco.languages.CompletionItemKind.Class,
-        insertText: symbol,
+        insertText: shouldInsertStlNameOnly
+          ? symbol.replace("std::", "")
+          : symbol,
         detail: "C++ Standard Library",
         range,
       }));
@@ -113,7 +152,7 @@ export function registerCppIntelliSense(monaco: typeof Monaco): Monaco.IDisposab
           kind: monaco.languages.CompletionItemKind.Snippet,
           insertText: "#include <iostream>",
           detail: "Include iostream",
-          range,
+          range: includeRange,
         },
         {
           label: "main",

--- a/apps/web/src/intellisense/cpp.ts
+++ b/apps/web/src/intellisense/cpp.ts
@@ -1,0 +1,156 @@
+import type * as Monaco from "monaco-editor";
+
+const C_CPP_KEYWORDS = [
+  "alignas",
+  "alignof",
+  "auto",
+  "bool",
+  "break",
+  "case",
+  "catch",
+  "char",
+  "class",
+  "const",
+  "constexpr",
+  "continue",
+  "default",
+  "delete",
+  "do",
+  "double",
+  "else",
+  "enum",
+  "explicit",
+  "false",
+  "float",
+  "for",
+  "friend",
+  "if",
+  "inline",
+  "int",
+  "long",
+  "namespace",
+  "new",
+  "nullptr",
+  "private",
+  "protected",
+  "public",
+  "return",
+  "short",
+  "signed",
+  "sizeof",
+  "static",
+  "struct",
+  "switch",
+  "template",
+  "this",
+  "throw",
+  "true",
+  "try",
+  "typedef",
+  "typename",
+  "using",
+  "void",
+  "while",
+];
+
+const STL_SUGGESTIONS = [
+  "std::array",
+  "std::cin",
+  "std::cout",
+  "std::endl",
+  "std::find",
+  "std::map",
+  "std::pair",
+  "std::queue",
+  "std::set",
+  "std::sort",
+  "std::stack",
+  "std::string",
+  "std::unordered_map",
+  "std::unordered_set",
+  "std::vector",
+];
+
+function createRange(
+  monaco: typeof Monaco,
+  model: Monaco.editor.ITextModel,
+  position: Monaco.Position,
+) {
+  const word = model.getWordUntilPosition(position);
+
+  return new monaco.Range(
+    position.lineNumber,
+    word.startColumn,
+    position.lineNumber,
+    word.endColumn,
+  );
+}
+
+export function registerCppIntelliSense(monaco: typeof Monaco): Monaco.IDisposable {
+  return monaco.languages.registerCompletionItemProvider("cpp", {
+    triggerCharacters: ["#", ".", ":", "<"],
+    provideCompletionItems(model, position) {
+      const range = createRange(monaco, model, position);
+
+      const keywordSuggestions = C_CPP_KEYWORDS.map((keyword) => ({
+        label: keyword,
+        kind: monaco.languages.CompletionItemKind.Keyword,
+        insertText: keyword,
+        range,
+      }));
+
+      const stlSuggestions = STL_SUGGESTIONS.map((symbol) => ({
+        label: symbol,
+        kind: monaco.languages.CompletionItemKind.Class,
+        insertText: symbol,
+        detail: "C++ Standard Library",
+        range,
+      }));
+
+      const snippetSuggestions = [
+        {
+          label: "#include <iostream>",
+          kind: monaco.languages.CompletionItemKind.Snippet,
+          insertText: "#include <iostream>",
+          detail: "Include iostream",
+          range,
+        },
+        {
+          label: "main",
+          kind: monaco.languages.CompletionItemKind.Snippet,
+          insertText: [
+            "int main() {",
+            "\t${1:// your code here}",
+            "\treturn 0;",
+            "}",
+          ].join("\n"),
+          insertTextRules:
+            monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          detail: "C++ main function",
+          range,
+        },
+        {
+          label: "for",
+          kind: monaco.languages.CompletionItemKind.Snippet,
+          insertText: [
+            "for (int ${1:i} = 0; ${1:i} < ${2:n}; ${1:i}++) {",
+            "\t${3:// loop body}",
+            "}",
+          ].join("\n"),
+          insertTextRules:
+            monaco.languages.CompletionItemInsertTextRule.InsertAsSnippet,
+          detail: "Indexed for loop",
+          range,
+        },
+      ];
+
+      return {
+        suggestions: [
+          ...keywordSuggestions,
+          ...stlSuggestions,
+          ...snippetSuggestions,
+        ],
+      };
+    },
+  });
+}

--- a/apps/web/src/intellisense/index.ts
+++ b/apps/web/src/intellisense/index.ts
@@ -1,0 +1,13 @@
+import type * as Monaco from "monaco-editor";
+import { registerCppIntelliSense } from "./cpp.js";
+
+const registeredLanguages = new Set<string>();
+
+export function registerEditorIntelliSense(monaco: typeof Monaco) {
+  if (registeredLanguages.has("cpp")) {
+    return;
+  }
+
+  registerCppIntelliSense(monaco);
+  registeredLanguages.add("cpp");
+}


### PR DESCRIPTION
## Linked issue
Closes #81

## GSSoC labels/level
- Official issue board: GSSoC 26
- Level: `level:beginner`
- Labels: `good first issue`, `frontend`, `enhancement`

## Summary
- Added a C++ Monaco completion provider with core language keywords.
- Added common STL suggestions such as `std::vector`, `std::cout`, `std::sort`, and containers.
- Added C++ snippets for `#include <iostream>`, `main()`, and indexed `for` loops with tab stops.
- Registered editor IntelliSense during Monaco editor mount without changing collaboration binding behavior.

## Validation
- `npm run build --workspace @tessera/shared-types`
- `npm run build --workspace @tessera/ui-components`
- `npm run build --workspace @tessera/collaboration`
- `npm run typecheck --workspace @tessera/web`
- `npm run build --workspace @tessera/web`

Note: Vite emitted the existing large chunk size warning during build; the build completed successfully.