### PR TITLE
feat: add Rust support to execution sandbox

### DIFF
--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -8,6 +8,7 @@ const LANGUAGE_IMAGES: Record<SupportedLanguage, string> = {
   python: "python:3.12-slim",
   cpp: "gcc:14",
   java: "openjdk:17-slim"
+  rust: "rust:1.75-slim",
 };
 
 const LANGUAGE_COMMANDS: Record<SupportedLanguage, (code: string) => string[]> = {
@@ -15,6 +16,7 @@ const LANGUAGE_COMMANDS: Record<SupportedLanguage, (code: string) => string[]> =
   python: (code) => ["python3", "-c", code],
   cpp: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.cpp && g++ -o /tmp/main /tmp/main.cpp && /tmp/main`],
   java: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/Main.java && javac /tmp/Main.java && java -cp /tmp Main`],
+  rust: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.rs && rustc /tmp/main.rs -o /tmp/main && /tmp/main`],
 };
 
 const DEFAULT_SANDBOX_CONFIG: SandboxConfig = {

--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -7,7 +7,7 @@ const LANGUAGE_IMAGES: Record<SupportedLanguage, string> = {
   typescript: "node:20-slim",
   python: "python:3.12-slim",
   cpp: "gcc:14",
-  java: "openjdk:17-slim"
+  java: "openjdk:17-slim",
   rust: "rust:1.75-slim",
 };
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,6 +16,7 @@ const FILE_NAMES: Record<SupportedLanguage, string> = {
   python: "main.py",
   cpp: "main.cpp",
   java: "Main.java",
+  rust: "main.rs"
 };
 
 export function App() {
@@ -90,6 +91,7 @@ export function App() {
               <option value="python">Python</option>
               <option value="cpp">C++</option>
               <option value="java">Java</option>
+              <option value="rust">Rust</option>
             </select>
           </div>
 

--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -19,6 +19,7 @@ const LANGUAGE_MAP: Record<SupportedLanguage, string> = {
   python: "python",
   cpp: "cpp",
   java: "java",
+  rust: "rust"
 };
 
 export function CollaborativeEditor({

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -5,7 +5,7 @@
 /**
  * Supported programming languages for code execution.
  */
-export type SupportedLanguage = "typescript" | "python" | "cpp" | "java";
+export type SupportedLanguage = "typescript" | "python" | "cpp" | "java" | "rust";
 
 /**
  * Status lifecycle of a code execution job.


### PR DESCRIPTION
## Description
Adds Rust language support to the execution sandbox, enabling users to compile and execute Rust programs in real time.

## Changes Made

- Added rust to the SupportedLanguage type.
- Added Rust Docker image configuration using `rust:1.75-slim`.
- Added Rust compilation and execution command using:
   `rustc main.rs -o main && ./main`.
- Added `main.rs` file name mapping in the web application.
- Added Rust syntax highlighting support in the collaborative editor.
- Added Rust as a selectable language in the UI language dropdown.
- 

Fixes #34

## Type of Change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore / Code maintenance (dependencies, workflows, formatting)

## How Has This Been Tested?
Run the following commands from the project root:
`npm run build`
Result: Build completed successfully with the Rust language support changes included.

To reproduce the Rust sandbox functionality locally:

1. Start the application:
`npm run dev`
2. Open the application in the browser.
3. Select Rust from the language dropdown.
4. Enter a simple Rust program, for example:

`fn main() {
    println!("Hello, Rust!");
}`

5. Execute the program.
6. Verify that the code compiles successfully and the expected output is displayed.

### Notes
npm run dev could not be fully verified in my local environment because the AI service requires uvicorn, which was not available. This limitation is unrelated to the Rust sandbox implementation. The production build completed successfully and included all Rust-related changes.

### Automated Verification
- [ ] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Existing/new tests pass (`npm run test`)

### Manual Verification
- [ ] Verified local dev environment works (`npm run dev`)
- [ ] Tested functionality in the browser / execution engine

Build completed successfully after the changes:
`npm run build`

- Notes
npm run dev could not be fully verified because the AI service requires uvicorn, which was not available in the local environment. This issue is unrelated to the Rust sandbox implementation.

## Checklist
- [ ] My commits are **signed off** using `git commit -s` (e.g. `Signed-off-by: Name <email>`).
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.
