### PR TITLE
feat(execution-engine): allow sandbox memory limit override via SANDBOX_MEMORY_LIMIT

### DIFF
--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -1,5 +1,10 @@
 import Dockerode from "dockerode";
-import type { ExecutionTask, ExecutionResult, SandboxConfig, SupportedLanguage } from "@tessera/shared-types";
+import type {
+  ExecutionTask,
+  ExecutionResult,
+  SandboxConfig,
+  SupportedLanguage,
+} from "@tessera/shared-types";
 
 const docker = new Dockerode({ socketPath: "/var/run/docker.sock" });
 
@@ -11,44 +16,96 @@ const LANGUAGE_IMAGES: Record<SupportedLanguage, string> = {
   rust: "rust:1.75-slim",
 };
 
-const LANGUAGE_COMMANDS: Record<SupportedLanguage, (code: string) => string[]> = {
+const LANGUAGE_COMMANDS: Record<
+  SupportedLanguage,
+  (code: string) => string[]
+> = {
   typescript: (code) => ["node", "--input-type=module", "-e", code],
+
   python: (code) => ["python3", "-c", code],
-  cpp: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.cpp && g++ -o /tmp/main /tmp/main.cpp && /tmp/main`],
-  java: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/Main.java && javac /tmp/Main.java && java -cp /tmp Main`],
-  rust: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.rs && rustc /tmp/main.rs -o /tmp/main && /tmp/main`],
+
+  cpp: (code) => [
+    "sh",
+    "-c",
+    `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.cpp && g++ -o /tmp/main /tmp/main.cpp && /tmp/main`,
+  ],
+
+  java: (code) => [
+    "sh",
+    "-c",
+    `echo '${code.replace(/'/g, "'\\''")}' > /tmp/Main.java && javac /tmp/Main.java && java -cp /tmp Main`,
+  ],
+
+  rust: (code) => [
+    "sh",
+    "-c",
+    `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.rs && rustc /tmp/main.rs -o /tmp/main && /tmp/main`,
+  ],
 };
+
+const DEFAULT_MEMORY_LIMIT_MB = 256;
 
 const DEFAULT_SANDBOX_CONFIG: SandboxConfig = {
   runtime: "runc",
-  memoryLimitMb: 256,
+  memoryLimitMb: DEFAULT_MEMORY_LIMIT_MB,
   cpuQuota: 100000,
   networkDisabled: true,
 };
 
 function detectRuntime(): SandboxConfig["runtime"] {
-  return process.env["SANDBOX_RUNTIME"] === "runsc" ? "runsc" : "runc";
+  return process.env["SANDBOX_RUNTIME"] === "runsc"
+    ? "runsc"
+    : "runc";
+}
+
+function detectMemoryLimit(): number {
+  const value = process.env["SANDBOX_MEMORY_LIMIT"];
+
+  if (!value) {
+    return DEFAULT_MEMORY_LIMIT_MB;
+  }
+
+  const parsed = Number.parseInt(value, 10);
+
+  return Number.isFinite(parsed) && parsed > 0
+    ? parsed
+    : DEFAULT_MEMORY_LIMIT_MB;
 }
 
 async function ensureImageExists(image: string): Promise<void> {
   try {
     await docker.getImage(image).inspect();
   } catch {
-    console.log(`[sandbox] pulling docker image: ${image} (this might take a moment)...`);
+    console.log(
+      `[sandbox] pulling docker image: ${image} (this might take a moment)...`
+    );
+
     const stream = await docker.pull(image);
+
     await new Promise<void>((resolve, reject) => {
       docker.modem.followProgress(stream, (err) => {
         if (err) reject(err);
         else resolve();
       });
     });
-    console.log(`[sandbox] successfully pulled image: ${image}`);
+
+    console.log(
+      `[sandbox] successfully pulled image: ${image}`
+    );
   }
 }
 
-export async function executeInSandbox(task: ExecutionTask): Promise<ExecutionResult> {
+export async function executeInSandbox(
+  task: ExecutionTask
+): Promise<ExecutionResult> {
   const startTime = performance.now();
-  const config: SandboxConfig = { ...DEFAULT_SANDBOX_CONFIG, runtime: detectRuntime() };
+
+  const config: SandboxConfig = {
+    ...DEFAULT_SANDBOX_CONFIG,
+    runtime: detectRuntime(),
+    memoryLimitMb: detectMemoryLimit(),
+  };
+
   const image = LANGUAGE_IMAGES[task.language];
   const cmd = LANGUAGE_COMMANDS[task.language](task.code);
 
@@ -88,22 +145,41 @@ export async function executeInSandbox(task: ExecutionTask): Promise<ExecutionRe
     });
 
     const waitPromise = container.wait();
-    const race = await Promise.race([waitPromise, timeoutPromise]);
+
+    const race = await Promise.race([
+      waitPromise,
+      timeoutPromise,
+    ]);
 
     if (race === "timeout") {
-      try { await container.stop({ t: 1 }); } catch { /* already stopped */ }
+      try {
+        await container.stop({ t: 1 });
+      } catch {
+        // already stopped
+      }
+
       return {
         taskId: task.id,
         status: "timeout",
         stdout: "",
-        stderr: `Execution timed out after ${String(task.timeoutMs)}ms`,
+        stderr: `Execution timed out after ${String(
+          task.timeoutMs
+        )}ms`,
         exitCode: null,
         durationMs: performance.now() - startTime,
       };
     }
 
-    const logs = await container.logs({ stdout: true, stderr: true, follow: false });
-    const logOutput = typeof logs === "string" ? logs : logs.toString("utf-8");
+    const logs = await container.logs({
+      stdout: true,
+      stderr: true,
+      follow: false,
+    });
+
+    const logOutput =
+      typeof logs === "string"
+        ? logs
+        : logs.toString("utf-8");
 
     const inspectInfo = await container.inspect();
     const exitCode = inspectInfo.State.ExitCode as number;
@@ -117,7 +193,9 @@ export async function executeInSandbox(task: ExecutionTask): Promise<ExecutionRe
       durationMs: performance.now() - startTime,
     };
   } catch (err: unknown) {
-    const message = err instanceof Error ? err.message : String(err);
+    const message =
+      err instanceof Error ? err.message : String(err);
+
     return {
       taskId: task.id,
       status: "failed",
@@ -128,7 +206,11 @@ export async function executeInSandbox(task: ExecutionTask): Promise<ExecutionRe
     };
   } finally {
     if (container) {
-      try { await container.remove({ force: true }); } catch { /* already removed */ }
+      try {
+        await container.remove({ force: true });
+      } catch {
+        // already removed
+      }
     }
   }
 }


### PR DESCRIPTION
## Description

Adds support for overriding the execution sandbox memory limit through the `SANDBOX_MEMORY_LIMIT` environment variable.

Previously, the sandbox memory cap was hardcoded to 256 MB in `DEFAULT_SANDBOX_CONFIG`. This change introduces environment-based configuration while preserving the existing default behavior when no environment variable is provided.

### Changes Made

- Added support for reading `SANDBOX_MEMORY_LIMIT` from process environment variables.
- Added validation to ensure only positive numeric values are accepted.
- Falls back to the default 256 MB memory limit when the variable is missing or invalid.
- Preserved existing sandbox behavior and resource configuration.

Fixes #35 

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification

- [x] `npm run typecheck` passes
- [x] `npm run build` passes

### Manual Verification

- [x] Tested functionality in the execution engine configuration by validating environment variable parsing and fallback behavior.

#### Verification Steps

1. Run without `SANDBOX_MEMORY_LIMIT` and verify the default 256 MB limit is used.
2. Run with a valid value such as:

   ```bash
   SANDBOX_MEMORY_LIMIT=512
   ```

   and verify the sandbox uses 512 MB.
3. Run with an invalid value and verify fallback to the default 256 MB limit.

## Checklist

- [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.