### PR TITLE
Improve cleanup logic in CollaborativeEditor

### DIFF
--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -35,6 +35,11 @@ export function CollaborativeEditor({
       const model = mountedEditor.getModel();
       if (!model) return;
 
+      // Clean up previous binding if it exists before initializing a new one
+      if (bindingRef.current) {
+        bindingRef.current.destroy();
+      }
+
       bindingRef.current = new MonacoBinding(
         ytext,
         model,
@@ -45,10 +50,17 @@ export function CollaborativeEditor({
     [ytext, awareness],
   );
 
+  // Clean up both the Monaco Binding and the editor instance on unmount to prevent memory leaks
   useEffect(() => {
     return () => {
-      bindingRef.current?.destroy();
-      bindingRef.current = null;
+      if (bindingRef.current) {
+        bindingRef.current.destroy();
+        bindingRef.current = null;
+      }
+      if (editorRef.current) {
+        editorRef.current.dispose();
+        editorRef.current = null;
+      }
     };
   }, []);
 


### PR DESCRIPTION
### 🎯 Purpose
Prevents client-side browser memory leaks by correctly disposing of the Monaco Editor standalone instance and wiping stale bindings during component unmount lifecycles.

### 🛠️ Changes Made
- Added `editorRef.current.dispose()` call inside the structural cleanup hook of `CollaborativeEditor.tsx`.
- Guaranteed that duplicate bindings are cleaned up safely if mounting actions run sequentially.

Closes #108
