### PR TITLE
chore: remove sign-off requirement from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,6 @@ Please delete options that are not relevant.
 - [ ] Tested functionality in the browser / execution engine
 
 ## Checklist
-- [ ] My commits are **signed off** using `git commit -s` (e.g. `Signed-off-by: Name <email>`).
 - [ ] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
 - [ ] My code follows the style guidelines of this project.
 - [ ] I have performed a self-review of my own code.


### PR DESCRIPTION
Removes the signed-off commits checklist item from the PR template. Contributors frequently miss this and it's not enforced by CI, causing unnecessary friction.