### PR TITLE
fix(collaboration): wrap applyUpdate in transact() to preserve cursor…

### DIFF
--- a/packages/collaboration/src/provider.ts
+++ b/packages/collaboration/src/provider.ts
@@ -68,18 +68,33 @@ export class TesseraSocketProvider {
     }
   };
 
+  // FIX: Wrapped Y.applyUpdate in ydoc.transact() with `this` as origin.
+  // Without transact(), y-monaco's `beforeAllTransactions` hook does not fire
+  // in time to snapshot the local cursor via _savedSelections, so the
+  // selection restore after the edit is a no-op → cursor jumps to 0.
+  // Wrapping in transact() guarantees the sequence:
+  //   1. beforeAllTransactions fires → cursor saved
+  //   2. applyUpdate runs → text changed
+  //   3. _ytextObserver fires → cursor restored
   private readonly handleSyncStep2 = (data: Uint8Array): void => {
     try {
-      Y.applyUpdate(this.ydoc, new Uint8Array(data), this);
+      this.ydoc.transact(() => {
+        Y.applyUpdate(this.ydoc, new Uint8Array(data), this);
+      }, this);
       this.synced = true;
     } catch (err: unknown) {
       console.error("[TesseraProvider] sync-step-2 error:", err);
     }
   };
 
+  // FIX: Same transact() wrap for every live keystroke update from a
+  // remote peer. This is the hot path — fires on every character typed
+  // by any other collaborator.
   private readonly handleSyncUpdate = (data: Uint8Array): void => {
     try {
-      Y.applyUpdate(this.ydoc, new Uint8Array(data), this);
+      this.ydoc.transact(() => {
+        Y.applyUpdate(this.ydoc, new Uint8Array(data), this);
+      }, this);
     } catch (err: unknown) {
       console.error("[TesseraProvider] sync-update error:", err);
     }
@@ -89,6 +104,7 @@ export class TesseraSocketProvider {
     update: Uint8Array,
     origin: unknown,
   ): void => {
+    // Skip updates that originated from this provider to avoid echo
     if (origin === this) return;
     this.socket.emit("sync-update", update);
   };


### PR DESCRIPTION
## Description

Fixes #123

When a remote collaborator typed, the local user's cursor jumped to position 0
and the editor lost focus on every incoming CRDT update.

**Root cause:** `TesseraSocketProvider` called `Y.applyUpdate()` without
wrapping it in `ydoc.transact()`. The `y-monaco` `MonacoBinding` relies on
Yjs firing `beforeAllTransactions` to snapshot the local cursor into
`_savedSelections` *before* any edit lands. Without `transact()`, that
snapshot was always empty, so cursor restore after the edit was a no-op.

**Fix:** Wrapped `Y.applyUpdate` in `this.ydoc.transact(() => {...}, this)`
in both `handleSyncStep2` and `handleSyncUpdate` inside
`packages/collaboration/src/provider.ts`. This guarantees the correct sequence:
1. `beforeAllTransactions` fires → local cursor saved to `_savedSelections`
2. `applyUpdate` runs → remote text applied via `executeEdits`
3. `_ytextObserver` fires → cursor restored from `_savedSelections`

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run typecheck` passes (10/10 tasks successful)
- [x] `npm run build` passes (7/7 tasks successful, 0 errors)

### Manual Verification
- [x] Opened the same room in two browser tabs
- [x] Both tabs placed cursor mid-document
- [x] Tab 2 typed rapidly — Tab 1 cursor no longer resets to position 0
- [x] Editor focus is preserved on Tab 1 throughout

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.