### PR TITLE
feat(web): add keyboard shortcut panel (Ctrl+/ or ?) to display edito…

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState, useEffect } from "react";
 import { SidePanel } from "@tessera/ui-components";
 import { CollaborativeEditor } from "./components/CollaborativeEditor.js";
+import { ShortcutsModal } from "./components/ShortcutsModal.js";
 import {
   useCollaboration,
   createDefaultParticipant,
@@ -23,6 +24,7 @@ export function App() {
   const [language, setLanguage] = useState<SupportedLanguage>("typescript");
   const [isRunning, setIsRunning] = useState(false);
   const [isAiPanelOpen, setIsAiPanelOpen] = useState(false);
+  const [isShortcutsOpen, setIsShortcutsOpen] = useState(false);
   const [output, setOutput] = useState<ExecutionResult | null>(null);
   const [showMinimap, setShowMinimap] = useState(true);
   const [fontSize, setFontSize] = useState(14);
@@ -52,6 +54,19 @@ export function App() {
       socket.off("execution-result", handleExecutionResult);
     };
   }, [socket]);
+
+
+  // Open shortcuts panel on Ctrl+/
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "/" && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        setIsShortcutsOpen((prev) => !prev);
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, []);
 
   const handleRunCode = () => {
     if (!socket || !ytext || isRunning) return;
@@ -128,6 +143,16 @@ export function App() {
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
+          </button>
+
+          <button
+            type="button"
+            onClick={() => setIsShortcutsOpen(true)}
+            className="flex items-center justify-center h-7 w-7 rounded border border-[var(--color-border)] bg-[var(--color-bg)] text-sm font-bold text-slate-400 hover:text-white hover:border-tessera-500 transition"
+            title="Keyboard shortcuts (Ctrl+/)"
+            aria-label="Open keyboard shortcuts panel"
+          >
+            ?
           </button>
 
           <button
@@ -270,6 +295,11 @@ export function App() {
           )}
         </div>
       </div>
+
+      <ShortcutsModal
+        open={isShortcutsOpen}
+        onClose={() => setIsShortcutsOpen(false)}
+      />
 
       <SidePanel
         open={isAiPanelOpen}

--- a/apps/web/src/components/ShortcutsModal.tsx
+++ b/apps/web/src/components/ShortcutsModal.tsx
@@ -1,0 +1,144 @@
+import { useEffect, useRef } from "react";
+
+interface ShortcutsModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const SHORTCUTS = [
+  {
+    category: "Editor",
+    items: [
+      { keys: ["Ctrl", "S"], action: "Format document" },
+      { keys: ["Ctrl", "Z"], action: "Undo" },
+      { keys: ["Ctrl", "Shift", "Z"], action: "Redo" },
+      { keys: ["Ctrl", "/"], action: "Toggle line comment" },
+      { keys: ["Ctrl", "F"], action: "Find in file" },
+      { keys: ["Ctrl", "G"], action: "Go to line" },
+    ],
+  },
+  {
+    category: "Execution",
+    items: [
+      { keys: ["Ctrl", "Enter"], action: "Run code" },
+      { keys: ["Ctrl", "Shift", "C"], action: "Clear output panel" },
+    ],
+  },
+  {
+    category: "Collaboration",
+    items: [
+      { keys: ["Ctrl", "Shift", "P"], action: "Toggle collaborators sidebar" },
+    ],
+  },
+  {
+    category: "General",
+    items: [
+      { keys: ["?"], action: "Open this shortcut panel" },
+      { keys: ["Escape"], action: "Close panel / dismiss overlay" },
+    ],
+  },
+];
+
+export function ShortcutsModal({ open, onClose }: ShortcutsModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Save and restore focus
+  useEffect(() => {
+    if (open) {
+      previousFocusRef.current = document.activeElement as HTMLElement;
+      dialogRef.current?.focus();
+    } else {
+      previousFocusRef.current?.focus();
+    }
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  return (
+    // Backdrop
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={onClose}
+      aria-hidden="true"
+    >
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Keyboard shortcuts"
+        tabIndex={-1}
+        className="relative w-full max-w-2xl max-h-[80vh] overflow-y-auto rounded-xl border border-[var(--color-border)] bg-[var(--color-surface)] shadow-2xl outline-none mx-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="flex items-center justify-between border-b border-[var(--color-border)] px-6 py-4">
+          <h2 className="text-base font-semibold text-white tracking-tight">
+            Keyboard Shortcuts
+          </h2>
+          <button
+            onClick={onClose}
+            className="flex items-center justify-center h-7 w-7 rounded text-slate-400 hover:text-white hover:bg-slate-700 transition"
+            aria-label="Close shortcuts panel"
+          >
+            ✕
+          </button>
+        </div>
+
+        {/* Shortcut groups */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-px bg-[var(--color-border)]">
+          {SHORTCUTS.map((group) => (
+            <div
+              key={group.category}
+              className="bg-[var(--color-surface)] px-6 py-4"
+            >
+              <p className="mb-3 text-xs font-semibold uppercase tracking-wider text-tessera-400">
+                {group.category}
+              </p>
+              <ul className="space-y-2">
+                {group.items.map((item) => (
+                  <li
+                    key={item.action}
+                    className="flex items-center justify-between gap-4"
+                  >
+                    <span className="text-sm text-slate-300">{item.action}</span>
+                    <span className="flex items-center gap-1 shrink-0">
+                      {item.keys.map((key, i) => (
+                        <span key={i} className="flex items-center gap-1">
+                          <kbd className="inline-block rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-1.5 py-0.5 text-xs font-mono font-medium text-slate-200 shadow-sm">
+                            {key}
+                          </kbd>
+                          {i < item.keys.length - 1 && (
+                            <span className="text-slate-600 text-xs">+</span>
+                          )}
+                        </span>
+                      ))}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+
+        {/* Footer */}
+        <div className="border-t border-[var(--color-border)] px-6 py-3">
+          <p className="text-xs text-slate-500 text-center">
+            Press <kbd className="inline-block rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-1 py-0.5 text-xs font-mono text-slate-300">Esc</kbd> or click outside to close
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Description

Closes #122

Adds a keyboard shortcut reference panel to the Tessera.io web client.

**Trigger:** `Ctrl+/` global keydown (or the new `?` button in the toolbar)  
**Dismiss:** `Escape` key or clicking the backdrop

**New file:** `apps/web/src/components/ShortcutsModal.tsx`  
**Modified:** `apps/web/src/App.tsx`

Shortcuts are grouped into 4 categories: Editor, Execution, Collaboration, and General. No new npm dependencies — built entirely with existing React hooks and Tailwind utility classes.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run typecheck` passes (10/10 tasks successful)

### Manual Verification
- [x] `Ctrl+/` opens the panel
- [x] `?` toolbar button opens the panel
- [x] `Escape` closes the panel
- [x] Clicking outside the modal closes it
- [x] Focus moves into the dialog on open and returns on close
- [x] All 4 shortcut groups render correctly

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.