### PR TITLE
feat: add Java sandbox support and fix dev server errors

### DIFF
--- a/apps/ai-service/package.json
+++ b/apps/ai-service/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "uvicorn src.main:app --reload --host 127.0.0.1 --port 8000",
+    "dev": "python -m uvicorn src.main:app --reload --host 127.0.0.1 --port 8000",
     "build": "echo 'Python service — no TS build required'",
     "typecheck": "echo 'Use mypy or pyright for Python type checking'",
     "clean": "find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null; true",

--- a/apps/sync-server/src/server.ts
+++ b/apps/sync-server/src/server.ts
@@ -57,6 +57,16 @@ const QUEUE_NAME = "code-execution";
 const executionQueue = new Queue<ExecutionTask>(QUEUE_NAME, { connection: connectionOptions });
 const queueEvents = new QueueEvents(QUEUE_NAME, { connection: connectionOptions });
 
+// Prevent unhandled Redis connection errors from crashing the process in dev
+// environments where Redis may not be running. The collaboration layer continues
+// to work; code execution jobs will fail gracefully per-request.
+executionQueue.on("error", (err) => {
+  console.warn("[sync-server] BullMQ Queue connection error (Redis unavailable?):", err.message);
+});
+queueEvents.on("error", (err) => {
+  console.warn("[sync-server] BullMQ QueueEvents error (Redis unavailable?):", err.message);
+});
+
 io.on("connection", (socket) => {
   let currentRoomId: string | null = null;
   let currentParticipant: Participant | null = null;
@@ -147,7 +157,7 @@ io.on("connection", (socket) => {
 
       console.log(`[sync-server] enqueuing code execution ${taskId} [lang=${payload.language}]`);
       const job = await executionQueue.add("execute", task, { jobId: taskId });
-      
+
       const result = await job.waitUntilFinished(queueEvents);
       console.log(`[sync-server] execution ${taskId} finished`);
       socket.emit("execution-result", result as ExecutionResult);

--- a/package-lock.json
+++ b/package-lock.json
@@ -386,6 +386,7 @@
       "os": [
         "aix"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -403,6 +404,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -420,6 +422,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -437,6 +440,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -454,6 +458,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -471,6 +476,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -488,6 +494,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -505,6 +512,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -522,6 +530,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -539,6 +548,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -556,6 +566,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -573,6 +584,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -590,6 +602,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -607,6 +620,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -624,6 +638,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -641,6 +656,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -658,6 +674,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -675,6 +692,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -692,6 +710,7 @@
       "os": [
         "netbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -709,6 +728,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -726,6 +746,7 @@
       "os": [
         "openbsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -743,6 +764,7 @@
       "os": [
         "openharmony"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -760,6 +782,7 @@
       "os": [
         "sunos"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -777,6 +800,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -794,6 +818,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -811,6 +836,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -3519,6 +3545,7 @@
       "os": [
         "android"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3540,6 +3567,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3561,6 +3589,7 @@
       "os": [
         "darwin"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3582,6 +3611,7 @@
       "os": [
         "freebsd"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3603,6 +3633,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3624,6 +3655,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3645,6 +3677,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3666,6 +3699,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3687,6 +3721,7 @@
       "os": [
         "linux"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3708,6 +3743,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3729,6 +3765,7 @@
       "os": [
         "win32"
       ],
+      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },


### PR DESCRIPTION
## Description

Fixes #55

This PR adds Java sandbox execution support to the code execution engine and fixes two dev server startup errors discovered during local verification.

### Changes

**[apps/execution-engine/src/sandbox.ts](cci:7://file:///d:/Github%20Commets/Tessera.io/apps/execution-engine/src/sandbox.ts:0:0-0:0)**
Java execution pipeline using the `openjdk:17-slim` Docker image. Source is written to `/tmp/Main.java`, compiled with `javac`, and executed via `java -cp /tmp Main`. Single quotes in submitted code are safely escaped using the POSIX `'\''` pattern to prevent shell injection.

**[apps/ai-service/package.json](cci:7://file:///d:/Github%20Commets/Tessera.io/apps/ai-service/package.json:0:0-0:0)**
Changed `dev` script from bare `uvicorn` to `python -m uvicorn`. On Windows, pip user-installs don't add script executables to `PATH`, so calling `uvicorn` directly fails. Using the module invocation form resolves this portably.

**[apps/sync-server/src/server.ts](cci:7://file:///d:/Github%20Commets/Tessera.io/apps/sync-server/src/server.ts:0:0-0:0)**
Added `.on('error', ...)` event handlers to the BullMQ `Queue` and `QueueEvents` instances. Without these, an `ECONNREFUSED` from Redis (when Redis isn't running locally) emits an unhandled `error` event and crashes the Node process. With the handler, the error is logged as a warning and the Yjs collaboration layer continues to function normally.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [ ] Existing/new tests pass (`npm run test`)

### Manual Verification
- [x] Verified local dev environment works (`npm run dev`)
  - `@tessera/ai-service` starts Uvicorn on `http://127.0.0.1:8000`
  - `@tessera/web` starts Vite on `http://localhost:3000`
  - `@tessera/sync-server` starts on `:4000`; Redis warning logged (non-fatal)
- [x] Tested functionality in the browser / execution engine
  - Java `Hello, World!` program compiles and executes successfully inside the `openjdk:17-slim` container
  - stdout is captured and returned correctly

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.
