### PR TITLE
Feat/add copy code clipboard button

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -8,6 +8,7 @@ import {
 import { isMacOS, getExecutionShortcutText } from "./utils/platformDetection.js";
 import type { SyncConnectionConfig, SupportedLanguage, ExecutionResult } from "@tessera/shared-types";
 import { downloadTextFile } from "./utils/downloadUtils.js";
+import { copyTextToClipboard } from "./utils/clipboardUtils.js";
 
 const SYNC_SERVER_URL = "http://localhost:4000";
 const DEFAULT_ROOM = "default-room";
@@ -28,6 +29,7 @@ export function App() {
   const [output, setOutput] = useState<ExecutionResult | null>(null);
   const [showMinimap, setShowMinimap] = useState(true);
   const [fontSize, setFontSize] = useState(14);
+  const [isCopied, setIsCopied] = useState(false);
 
   const config = useMemo<SyncConnectionConfig>(
     () => ({
@@ -84,6 +86,18 @@ export function App() {
     if (!ytext) return;
     downloadTextFile(ytext.toString(), FILE_NAMES[language]);
   };
+
+  const handleCopyCode = async () => {
+    if (!ytext) return;
+    try {
+      await copyTextToClipboard(ytext.toString());
+      setIsCopied(true);
+      setTimeout(() => setIsCopied(false), 2000);
+    } catch {
+      // Clipboard write can fail when the page is not focused or
+      // the user has denied clipboard permissions — fail silently.
+    }
+  };
   return (
     <div className="flex h-screen flex-col bg-[var(--color-bg)]">
       {/* Header */}
@@ -116,13 +130,12 @@ export function App() {
             onClick={handleRunCode}
             disabled={!connected || isRunning}
             title={`Run code (${getExecutionShortcutText()})`}
-            className={`flex items-center gap-1.5 px-3 py-1 text-sm font-semibold rounded transition shadow-sm ${
-              isRunning
-                ? "bg-slate-700 text-slate-400 cursor-not-allowed"
-                : !connected
+            className={`flex items-center gap-1.5 px-3 py-1 text-sm font-semibold rounded transition shadow-sm ${isRunning
+              ? "bg-slate-700 text-slate-400 cursor-not-allowed"
+              : !connected
                 ? "bg-slate-800 text-slate-500 cursor-not-allowed"
                 : "bg-tessera-600 hover:bg-tessera-500 text-white cursor-pointer active:scale-95"
-            }`}
+              }`}
           >
             {isRunning ? (
               <>
@@ -147,6 +160,24 @@ export function App() {
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
+          </button>
+
+          {/* Copy Code Button */}
+          <button
+            onClick={handleCopyCode}
+            disabled={!ytext}
+            className="flex items-center justify-center p-1.5 text-slate-400 hover:text-white hover:bg-[var(--color-bg)] rounded transition disabled:opacity-40 disabled:cursor-not-allowed"
+            title="Copy code to clipboard"
+          >
+            {isCopied ? (
+              <svg className="h-4 w-4 text-emerald-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+              </svg>
+            ) : (
+              <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+            )}
           </button>
 
           <button

--- a/apps/web/src/utils/clipboardUtils.test.ts
+++ b/apps/web/src/utils/clipboardUtils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { copyTextToClipboard } from "./clipboardUtils.js";
+
+describe("copyTextToClipboard", () => {
+    beforeEach(() => {
+        vi.stubGlobal("navigator", {
+            clipboard: {
+                writeText: vi.fn(),
+            },
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it("calls navigator.clipboard.writeText with the provided text", async () => {
+        const writeText = vi
+            .spyOn(navigator.clipboard, "writeText")
+            .mockResolvedValue(undefined);
+
+        await copyTextToClipboard("const hello = 'world';");
+
+        expect(writeText).toHaveBeenCalledOnce();
+        expect(writeText).toHaveBeenCalledWith("const hello = 'world';");
+    });
+
+    it("copies an empty string without throwing", async () => {
+        vi.spyOn(navigator.clipboard, "writeText").mockResolvedValue(undefined);
+
+        await expect(copyTextToClipboard("")).resolves.toBeUndefined();
+    });
+
+    it("propagates clipboard API rejection to the caller", async () => {
+        const clipboardError = new DOMException(
+            "NotAllowedError",
+            "Write permission denied.",
+        );
+        vi.spyOn(navigator.clipboard, "writeText").mockRejectedValue(clipboardError);
+
+        await expect(copyTextToClipboard("some code")).rejects.toThrow(
+            "NotAllowedError",
+        );
+    });
+});

--- a/apps/web/src/utils/clipboardUtils.ts
+++ b/apps/web/src/utils/clipboardUtils.ts
@@ -1,0 +1,12 @@
+/**
+ * Copies the given text to the system clipboard using the
+ * Clipboard API.  Callers should handle the returned Promise so
+ * that permission-denied or insecure-context errors (browser
+ * blocks clipboard in non-HTTPS / non-localhost contexts) are
+ * surfaced gracefully.
+ *
+ * @param text - The text content to copy to the clipboard
+ */
+export async function copyTextToClipboard(text: string): Promise<void> {
+    await navigator.clipboard.writeText(text);
+}


### PR DESCRIPTION
## Description

Adds a **Copy Code** button to the editor header toolbar that copies the entire collaborative editor buffer (`ytext.toString()`) to the system clipboard with a single click.

Fixes #27

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Existing/new tests pass (`npm run test`) — 7/7 tests pass (3 new for clipboard + 4 existing)

### Manual Verification
- [x] Button sitting between Download icon and AI Panel button works as expected.
- [x] Visual feedback (green checkmark for 2s) confirms successful copy.
- [x] Button disabled state correctly mirrors editor connection state.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.

## Changes

### `apps/web/src/utils/clipboardUtils.ts` (new)
Pure utility wrapping `navigator.clipboard.writeText`.

### `apps/web/src/utils/clipboardUtils.test.ts` (new)
Unit tests for the new clipboard utility.

### `apps/web/src/App.tsx` (modified)
Integrated the clipboard button and logic into the header toolbar.
