### PR TITLE
feat(sync-server): add heartbeat-based participant presence tracking

### DIFF
--- a/apps/sync-server/src/server.ts
+++ b/apps/sync-server/src/server.ts
@@ -247,7 +247,7 @@ io.on("connection", (socket) => {
     const room = rooms.get(currentRoomId);
     if (!room) return;
 
-    room.participants.delete(socket.id);
+    removeParticipant(room, socket.id);
 
     if (currentParticipant) {
       removeAwarenessStates(room.awareness, [room.awareness.clientID], socket);
@@ -260,6 +260,15 @@ io.on("connection", (socket) => {
   });
 });
 
+// Remove a participant from the room's presence registry.
+// This helper is used by both disconnect handling and
+// heartbeat expiration cleanup.
+function removeParticipant(
+  room: RoomState,
+  socketId: string,
+): void {
+  room.participants.delete(socketId);
+}
 
 
 server.listen(PORT, () => {

--- a/apps/sync-server/src/server.ts
+++ b/apps/sync-server/src/server.ts
@@ -29,11 +29,22 @@ interface RoomState {
   // heartbeat-based presence tracking.
   readonly participants: Map<string, ParticipantPresence>;
 }
+
+// Participants that have not sent a heartbeat within this
+// interval are considered stale and will be removed.
+const PRESENCE_TIMEOUT_MS = 60_000;
+
+// Frequency of stale participant cleanup checks.
+const PRESENCE_CLEANUP_INTERVAL_MS = 30_000;
+
 const PORT = Number(process.env["PORT"] ?? 4000);
 const CORS_ORIGIN = process.env["CORS_ORIGIN"] ?? "http://localhost:3000";
 const REDIS_HOST = process.env["REDIS_HOST"] ?? "127.0.0.1";
 const REDIS_PORT = Number(process.env["REDIS_PORT"] ?? 6379);
 
+// Active collaboration rooms maintained in-memory.
+// Presence cleanup periodically scans these rooms and removes
+// participants that stop sending heartbeats.
 const rooms = new Map<string, RoomState>();
 
 function getOrCreateRoom(roomId: string): RoomState {
@@ -73,6 +84,33 @@ const executionQueue = new Queue<ExecutionTask>(QUEUE_NAME, { connection: connec
 // internally, so there is no risk of cross-job event mixups.
 const queueEvents = new QueueEvents(QUEUE_NAME, { connection: connectionOptions });
 
+// Periodically remove stale participants that have stopped
+// sending heartbeats.
+const presenceCleanupTimer = setInterval(
+  cleanupStaleParticipants,
+  PRESENCE_CLEANUP_INTERVAL_MS,
+
+);
+
+
+// Remove participants whose heartbeat timestamps have expired.
+// This protects against ghost users caused by network drops,
+// browser crashes, and missed disconnect events.
+function cleanupStaleParticipants(): void {
+  const now = Date.now();
+  for (const [, room] of rooms) {
+    for (const [socketId, presence] of room.participants) {
+      if (now - presence.lastSeen > PRESENCE_TIMEOUT_MS) {
+        room.participants.delete(socketId);
+        console.log(
+          `[presence] participant expired [socket=${socketId}]`
+        );
+      }
+    }
+
+  }
+}
+
 io.on("connection", (socket) => {
   let currentRoomId: string | null = null;
   let currentParticipant: Participant | null = null;
@@ -101,6 +139,8 @@ io.on("connection", (socket) => {
     const stateVector = Y.encodeStateVector(room.doc);
     socket.emit("sync-step-1", stateVector);
   });
+
+
 
   // Refresh participant liveness whenever a heartbeat arrives.
   // This timestamp will later be used by the cleanup scheduler
@@ -220,11 +260,16 @@ io.on("connection", (socket) => {
   });
 });
 
+
+
 server.listen(PORT, () => {
   console.log(`sync-server listening on :${String(PORT)}`);
 });
 
 async function gracefulShutdown() {
+  // Stop stale participant cleanup before shutdown.
+  clearInterval(presenceCleanupTimer);
+
   console.log("shutting down sync-server…");
   try {
     await Promise.all([executionQueue.close(), queueEvents.close()]);

--- a/apps/sync-server/src/server.ts
+++ b/apps/sync-server/src/server.ts
@@ -13,12 +13,22 @@ import type {
   ExecutionResult,
 } from "@tessera/shared-types";
 
+// Tracks participant metadata together with the most recent
+// heartbeat timestamp used for presence reconciliation.
+
+interface ParticipantPresence {
+  participant: Participant;
+  lastSeen: number;
+}
+
 interface RoomState {
   readonly doc: Y.Doc;
   readonly awareness: Awareness;
-  readonly participants: Map<string, Participant>;
+  // Active participants keyed by socket.id.
+  // Each entry stores liveness information used for
+  // heartbeat-based presence tracking.
+  readonly participants: Map<string, ParticipantPresence>;
 }
-
 const PORT = Number(process.env["PORT"] ?? 4000);
 const CORS_ORIGIN = process.env["CORS_ORIGIN"] ?? "http://localhost:3000";
 const REDIS_HOST = process.env["REDIS_HOST"] ?? "127.0.0.1";
@@ -73,18 +83,40 @@ io.on("connection", (socket) => {
 
     currentRoomId = roomId;
     currentParticipant = participant;
-    room.participants.set(socket.id, participant);
-
+    room.participants.set(socket.id, {
+      participant,
+      lastSeen: Date.now(),
+    });
     void socket.join(roomId);
 
     socket.emit("room-joined", {
       roomId,
-      participants: Array.from(room.participants.values()),
+      participants: Array.from(
+        // Initialize participant presence tracking when a user joins.
+        // lastSeen is refreshed by future heartbeat events.
+        room.participants.values(),
+      ).map((presence) => presence.participant),
     });
 
     const stateVector = Y.encodeStateVector(room.doc);
     socket.emit("sync-step-1", stateVector);
   });
+
+  // Refresh participant liveness whenever a heartbeat arrives.
+  // This timestamp will later be used by the cleanup scheduler
+  // to remove stale participants and awareness states.
+  socket.on("presence-heartbeat", () => {
+    if (!currentRoomId) return;
+
+    const room = rooms.get(currentRoomId);
+    if (!room) return;
+
+    const presence = room.participants.get(socket.id);
+    if (!presence) return;
+
+    presence.lastSeen = Date.now();
+  });
+
 
   socket.on("sync-step-1", (data) => {
     if (!currentRoomId) return;

--- a/apps/sync-server/src/server.ts
+++ b/apps/sync-server/src/server.ts
@@ -92,24 +92,52 @@ const presenceCleanupTimer = setInterval(
 
 );
 
-
-// Remove participants whose heartbeat timestamps have expired.
-// This protects against ghost users caused by network drops,
-// browser crashes, and missed disconnect events.
 function cleanupStaleParticipants(): void {
   const now = Date.now();
+
   for (const [, room] of rooms) {
     for (const [socketId, presence] of room.participants) {
       if (now - presence.lastSeen > PRESENCE_TIMEOUT_MS) {
+
+        // Remove any awareness states associated with the expired participant.
+        // This ensures cursors and presence indicators are cleaned up even when
+        // a client disappears without a graceful disconnect (network loss,
+        // browser crash, etc.).
+        const expiredClientIds: number[] = [];
+
+        room.awareness.getStates().forEach((state, clientId) => {
+          const awarenessParticipant =
+            (state as Record<string, unknown>)["participant"] as
+              Participant | undefined;
+
+          if (
+            awarenessParticipant &&
+            awarenessParticipant.id === presence.participant.id
+          ) {
+            expiredClientIds.push(clientId);
+          }
+        });
+
+        if (expiredClientIds.length > 0) {
+          removeAwarenessStates(
+            room.awareness,
+            expiredClientIds,
+            "presence-timeout",
+          );
+        }
+
         room.participants.delete(socketId);
+
         console.log(
-          `[presence] participant expired [socket=${socketId}]`
+          `[presence] participant expired [socket=${socketId}]`,
         );
       }
     }
-
   }
 }
+
+  
+
 
 io.on("connection", (socket) => {
   let currentRoomId: string | null = null;

--- a/apps/web/src/hooks/useCollaboration.ts
+++ b/apps/web/src/hooks/useCollaboration.ts
@@ -74,16 +74,23 @@ export function useCollaboration(config: SyncConnectionConfig): UseCollaboration
 
     socket.on("connect", () => {
       setConnected(true);
+
       socket.emit("join-room", {
         roomId: config.roomId,
         participant: config.participant,
       });
+
+      // Recreate the provider after reconnects. Any existing
+      // provider must be cleaned up first to avoid duplicate
+      // event listeners and heartbeat timers.
+      providerRef.current?.destroy();
 
       const provider = new TesseraSocketProvider({
         socket,
         ydoc: collabDoc.ydoc,
         awareness: awarenessInstance,
       });
+
       providerRef.current = provider;
     });
 

--- a/packages/collaboration/src/provider.ts
+++ b/packages/collaboration/src/provider.ts
@@ -28,6 +28,7 @@ export class TesseraSocketProvider {
     this.bindSocketListeners();
     this.bindDocListeners();
     this.sendSyncStep1();
+    this.startHeartbeat();
   }
 
   get isSynced(): boolean {
@@ -35,6 +36,11 @@ export class TesseraSocketProvider {
   }
 
   destroy(): void {
+    // Stop sending presence heartbeats after provider shutdown.
+    if (this.heartbeatTimer) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
     if (this.destroyed) return;
     this.destroyed = true;
 
@@ -52,23 +58,40 @@ export class TesseraSocketProvider {
     this.socket.off("awareness-update", this.handleAwarenessRemoteUpdate);
   }
 
-  /**
+/**
  * Deletes all content from the shared Monaco text in a single atomic
  * Yjs transaction, propagating the deletion to all synced clients via
  * the existing sync-update socket pipeline.
  */
-  clearLocalDoc(): void {
-    if (this.destroyed) return;
-    const ytext = this.ydoc.getText("monaco");
-    if (ytext.length === 0) return;
-    this.ydoc.transact(() => {
-      ytext.delete(0, ytext.length);
-    });
-  }
+clearLocalDoc(): void {
+  if (this.destroyed) return;
+
+  const ytext = this.ydoc.getText("monaco");
+  if (ytext.length === 0) return;
+
+  this.ydoc.transact(() => {
+    ytext.delete(0, ytext.length);
+  });
+}
+
+// Periodically notify the sync server that this participant
+// is still active. These heartbeats are used for presence
+// reconciliation and stale participant cleanup.
+private static readonly HEARTBEAT_INTERVAL_MS = 15_000;
+
+private heartbeatTimer: ReturnType<typeof setInterval> | null = null;
 
   private sendSyncStep1(): void {
     const stateVector = Y.encodeStateVector(this.ydoc);
     this.socket.emit("sync-step-1", stateVector);
+  }
+
+  // Begin periodically reporting participant liveness to the
+  // sync server.
+  private startHeartbeat(): void {
+    this.heartbeatTimer = setInterval(() => {
+      this.socket.emit("presence-heartbeat");
+    }, TesseraSocketProvider.HEARTBEAT_INTERVAL_MS);
   }
 
   private bindSocketListeners(): void {

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -86,6 +86,12 @@ export interface SyncClientToServerEvents {
     readonly roomId: string;
     readonly participant: Participant;
   }) => void;
+
+// Heartbeat event used to track participant liveness.
+// The server already knows the participant's active room from
+// the socket session, so no additional payload is required.
+  readonly "presence-heartbeat": () => void;
+
   readonly "sync-step-1": (stateVector: Uint8Array) => void;
   readonly "sync-step-2": (diff: Uint8Array) => void;
   readonly "sync-update": (update: Uint8Array) => void;
@@ -95,7 +101,6 @@ export interface SyncClientToServerEvents {
     readonly language: SupportedLanguage;
   }) => void;
 }
-
 export interface SyncServerToClientEvents {
   readonly "sync-step-1": (stateVector: Uint8Array) => void;
   readonly "sync-step-2": (diff: Uint8Array) => void;


### PR DESCRIPTION
## Description
<!-- Provide a clear description of the changes you've made, and the problem/issue it solves. -->
Introduces heartbeat-based participant presence tracking infrastructure for collaborative sessions.

Changes Made:
Added presence-heartbeat socket event to shared types.
Added participant presence metadata with lastSeen timestamps.
Implemented server-side heartbeat handling to refresh participant liveness.
Implemented client-side heartbeat emission in TesseraSocketProvider.
Added provider cleanup before reconnect reinitialization to prevent duplicate event listeners and heartbeat timers.
Added inline comments documenting the presence lifecycle and reconnect behavior.

This change establishes the foundation required for future participant expiration and presence reconciliation improvements.

Fixes #128  <!-- Issue number goes here, e.g. Fixes #123 -->

## Type of Change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Chore / Code maintenance (dependencies, workflows, formatting)

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

### Automated Verification
- [ ] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Existing/new tests pass (`npm run test`)

### Manual Verification
- [ ] Verified local dev environment works (`npm run dev`)
- [ ] Tested functionality in the browser / execution engine

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.
