### PR TITLE
chore: overhaul issue claiming workflow to prevent hoarding

### DIFF
--- a/.github/workflows/issue-claim.yml
+++ b/.github/workflows/issue-claim.yml
@@ -21,7 +21,17 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           COMMENTER: ${{ github.event.comment.user.login }}
+          AUTHOR: ${{ github.event.issue.user.login }}
+          AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
         run: |
+          # Prevent self-claiming by non-maintainers
+          if [ "$COMMENTER" = "$AUTHOR" ]; then
+            if [ "$AUTHOR_ASSOCIATION" != "OWNER" ] && [ "$AUTHOR_ASSOCIATION" != "MEMBER" ] && [ "$AUTHOR_ASSOCIATION" != "COLLABORATOR" ]; then
+              gh issue comment "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --body "Hi @$COMMENTER, contributors cannot use \`/claim\` on issues they opened themselves. A maintainer will review your issue and assign it if approved!"
+              exit 0
+            fi
+          fi
+
           # Fetch list of existing assignees
           ASSIGNEES=$(gh issue view "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --json assignees -q '.assignees[].login')
 

--- a/.github/workflows/unassign-stale.yml
+++ b/.github/workflows/unassign-stale.yml
@@ -1,0 +1,49 @@
+name: Unassign Stale Issues
+
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run at midnight UTC daily
+  workflow_dispatch: # Allow manual triggers
+
+permissions:
+  issues: write
+
+jobs:
+  unassign:
+    name: Unassign Stale Issues
+    runs-on: ubuntu-latest
+    steps:
+      - name: Find and unassign stale issues
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Calculate the date 3 days ago
+          DATE_LIMIT=$(date -d "3 days ago" -I)
+          
+          # Find open assigned issues not updated in the last 3 days
+          # We use `jq` to extract just the issue numbers
+          STALE_ISSUES=$(gh issue list --search "is:issue is:open has:assignee updated:<=$DATE_LIMIT" --json number -q '.[].number')
+          
+          if [ -z "$STALE_ISSUES" ]; then
+            echo "No stale assigned issues found."
+            exit 0
+          fi
+          
+          echo "Found stale issues: $STALE_ISSUES"
+          
+          for ISSUE in $STALE_ISSUES; do
+            echo "Processing issue #$ISSUE"
+            
+            # Fetch existing assignees as a comma-separated list
+            ASSIGNEES=$(gh issue view "$ISSUE" --repo "$GITHUB_REPOSITORY" --json assignees -q '.assignees[].login' | paste -sd, -)
+            
+            if [ -n "$ASSIGNEES" ]; then
+              # Remove assignees
+              gh issue edit "$ISSUE" --repo "$GITHUB_REPOSITORY" --remove-assignee "$ASSIGNEES"
+              
+              # Add comment
+              gh issue comment "$ISSUE" --repo "$GITHUB_REPOSITORY" --body "This issue has been inactive for 3 days and has been automatically unassigned to allow others to work on it. Feel free to claim it again when you are ready to work on it!"
+              
+              echo "Successfully unassigned $ASSIGNEES from issue #$ISSUE."
+            fi
+          done


### PR DESCRIPTION
This PR overhauls the issue claiming workflow based on maintainer guidelines:

1. **Prevents self-claiming**: Contributors can no longer use `/claim` on issues they opened themselves unless they are a maintainer.
2. **3-day inactivity rule**: Added `unassign-stale.yml` which runs daily to unassign any assigned issues that haven't had activity in 3 days.

This stops the pattern of contributors opening issues and immediately claiming them before review, and automatically frees up hoarded issues.