### PR TITLE
feat(execution-engine): add cleanup script for dead sandbox containers

### DIFF
--- a/apps/execution-engine/package.json
+++ b/apps/execution-engine/package.json
@@ -9,7 +9,9 @@
     "start": "node dist/worker.js",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "lint": "echo 'lint not configured yet'"
+    "lint": "echo 'lint not configured yet'",
+    "cleanup": "tsx src/cleanup.ts",
+    "cleanup:docker": "npm run cleanup"
   },
   "dependencies": {
     "@tessera/shared-types": "*",

--- a/apps/execution-engine/src/cleanup.ts
+++ b/apps/execution-engine/src/cleanup.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+
+import Dockerode from "dockerode";
+
+// Initialize Docker with auto-detection (works on Windows & Linux)
+let docker: Dockerode;
+
+try {
+  docker = new Dockerode();
+} catch (error) {
+  console.error("❌ Failed to connect to Docker daemon. Make sure Docker is running.");
+  console.error("   Error:", error instanceof Error ? error.message : error);
+  process.exit(1);
+}
+
+interface ContainerInfo {
+  id: string;
+  name: string;
+  status: string;
+  created: number;
+}
+
+async function cleanupDeadSandboxContainers(): Promise<void> {
+  console.log("\n🔍 Scanning for dead sandbox containers...\n");
+
+  try {
+    if (!docker) {
+      console.error("❌ Docker is not available. Please ensure Docker is running.\n");
+      process.exit(1);
+    }
+
+    const containers = await docker.listContainers({ all: true });
+
+    if (!containers || containers.length === 0) {
+      console.log("✅ No containers found.\n");
+      return;
+    }
+
+    const deadContainers = containers.filter((container) => {
+      const isSandbox = container.Names?.some(
+        (name) =>
+          name?.includes("sandbox") ||
+          name?.includes("execution") ||
+          name?.includes("tessera")
+      ) || false;
+      
+      const isDeadOrExited =
+        container.State === "exited" ||
+        container.State === "dead" ||
+        container.Status?.includes("exited") ||
+        false;
+        
+      return isSandbox && isDeadOrExited;
+    });
+
+    if (deadContainers.length === 0) {
+      console.log("✅ No dead sandbox containers found.\n");
+      return;
+    }
+
+    console.log(`📦 Found ${deadContainers.length} dead sandbox container(s):\n`);
+
+    for (const container of deadContainers) {
+      const containerName = container.Names?.[0]?.replace("/", "") || "unknown";
+      const containerId = container.Id?.substring(0, 12) || "unknown";
+      
+      console.log(`   🗑️  ${containerName} (${containerId}) - Status: ${container.State || "unknown"}`);
+
+      try {
+        const dockerContainer = docker.getContainer(container.Id);
+        await dockerContainer.remove({ force: true });
+        console.log(`      ✅ Removed successfully\n`);
+      } catch (removeError) {
+        console.error(
+          `      ❌ Failed to remove:`,
+          removeError instanceof Error ? removeError.message : removeError
+        );
+        console.log("");
+      }
+    }
+
+    console.log("✨ Cleanup completed!\n");
+  } catch (error) {
+    console.error(
+      "💥 Error during cleanup:",
+      error instanceof Error ? error.message : error
+    );
+    process.exit(1);
+  }
+}
+
+// Run the function directly
+cleanupDeadSandboxContainers();
+
+export { cleanupDeadSandboxContainers };

--- a/apps/execution-engine/src/cleanup.ts
+++ b/apps/execution-engine/src/cleanup.ts
@@ -2,7 +2,7 @@
 
 import Dockerode from "dockerode";
 
-// Initialize Docker with auto-detection (works on Windows & Linux)
+// Initialize Docker with auto-detection
 let docker: Dockerode;
 
 try {
@@ -11,13 +11,6 @@ try {
   console.error("❌ Failed to connect to Docker daemon. Make sure Docker is running.");
   console.error("   Error:", error instanceof Error ? error.message : error);
   process.exit(1);
-}
-
-interface ContainerInfo {
-  id: string;
-  name: string;
-  status: string;
-  created: number;
 }
 
 async function cleanupDeadSandboxContainers(): Promise<void> {
@@ -89,7 +82,7 @@ async function cleanupDeadSandboxContainers(): Promise<void> {
   }
 }
 
-// Run the function directly
-cleanupDeadSandboxContainers();
+// Run the cleanup function
+cleanupDeadSandboxContainers().catch(console.error);
 
 export { cleanupDeadSandboxContainers };

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test": "turbo run test",
     "lint": "turbo run lint",
     "typecheck": "turbo run typecheck",
-    "clean": "turbo run clean && rm -rf node_modules"
+    "clean": "turbo run clean && rm -rf node_modules",
+    "cleanup": "npm run cleanup --workspace=@tessera/execution-engine"
   },
   "devDependencies": {
     "turbo": "^2.9.16",


### PR DESCRIPTION
## Issue

Fixes #44

## Changes Made

### New File: `apps/execution-engine/src/cleanup.ts`

- Added a cleanup script to identify and remove dead/exited sandbox containers.
- Automatically detects the Docker socket for both Windows and Linux environments.
- Filters containers based on relevant names such as `sandbox`, `execution`, and `tessera`.

### Modified: `apps/execution-engine/package.json`

- Added the following script:

```json
"cleanup": "tsx src/cleanup.ts"
```

### Modified: Root `package.json`

- Added the following script:

```json
"cleanup": "npm run cleanup --workspace=@tessera/execution-engine"
```

## Usage

```bash
npm run cleanup
```

## Example Output

```text
🔍 Scanning for dead sandbox containers...
✅ No dead sandbox containers found.
```

## Testing

- TypeScript compiles successfully without errors.
- Script handles Docker connection failures gracefully.
- Dead/exited containers are filtered and cleaned up correctly.

## GSSoC'26

Contributed as part of GirlScript Summer of Code 2026.