### PR TITLE
feat(execution-engine): format C++ compiler error messages into visua…

### DIFF
--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -123,6 +123,102 @@ async function ensureImageExists(image: string): Promise<void> {
   }
 }
 
+/**
+ * Parses and formats raw g++ compiler error logs into clean, boxed visual frames.
+ */
+export function formatCppCompilerErrors(rawLogs: string): string {
+  // Clean Docker stream multiplexing headers (starts with stream type 1 or 2, followed by 3 null bytes and 4 length bytes)
+  const cleanedLogs = rawLogs.replace(/[\u0000-\u0002]\u0000\u0000\u0000[\s\S]{4}/g, "");
+
+  const lines = cleanedLogs.split("\n");
+  const result: string[] = [];
+  let isBlockOpen = false;
+
+  const closeBlock = () => {
+    if (isBlockOpen) {
+      result.push("└" + "─".repeat(78));
+      result.push(""); // spacing line
+      isBlockOpen = false;
+    }
+  };
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+
+    const trimmedLine = line.trim();
+
+    // Match compiler error/warning header e.g. /tmp/main.cpp:5:5: error: 'cout' is not a member of 'std'
+    const errorRegex = /^\/tmp\/main\.cpp:(\d+):(\d+):\s*(error|warning|note):\s*(.*)$/i;
+    const errorMatch = line.match(errorRegex);
+
+    if (errorMatch) {
+      closeBlock();
+
+      const lineNum = errorMatch[1] ?? "";
+      const colNum = errorMatch[2] ?? "";
+      const severity = errorMatch[3] ?? "";
+      const message = errorMatch[4] ?? "";
+
+      let label = "❌ ERROR";
+      if (severity.toLowerCase() === "warning") {
+        label = "⚠️ WARNING";
+      } else if (severity.toLowerCase() === "note") {
+        label = "ℹ️ NOTE";
+      }
+
+      const headerText = `── ${label} (Line ${lineNum}, Col ${colNum}) `;
+      const fillLength = Math.max(2, 80 - headerText.length);
+
+      result.push(`┌${headerText}${"─".repeat(fillLength)}`);
+      result.push(`│  Message: ${message}`);
+      result.push(`│`);
+      isBlockOpen = true;
+      continue;
+    }
+
+    // Match compiler context line e.g. /tmp/main.cpp: In function 'int main()':
+    const contextRegex = /^\/tmp\/main\.cpp:\s*In\s+function\s+['"](.*)['"]\s*:/i;
+    const contextMatch = line.match(contextRegex);
+    if (contextMatch) {
+      closeBlock();
+      const functionName = contextMatch[1] ?? "unknown";
+      result.push(`👉 In function '${functionName}':`);
+      result.push("");
+      continue;
+    }
+
+    if (isBlockOpen) {
+      if (trimmedLine === "") {
+        result.push("│");
+        continue;
+      }
+
+      const cleanedLine = line.replace(/\/tmp\/main\.cpp/g, "main.cpp");
+      const isCodeOrPointerLine = /^\s*\d*\s*\|/i.test(cleanedLine);
+
+      if (isCodeOrPointerLine) {
+        result.push(`│  ${cleanedLine.trimEnd()}`);
+      } else {
+        result.push(`│  ${cleanedLine}`);
+      }
+    } else {
+      if (trimmedLine !== "") {
+        result.push(line.replace(/\/tmp\/main\.cpp/g, "main.cpp"));
+      }
+    }
+  }
+
+  closeBlock();
+
+  // Trim trailing empty lines
+  while (result.length > 0 && result[result.length - 1] === "") {
+    result.pop();
+  }
+
+  return result.join("\n");
+}
+
 export async function executeInSandbox(
   task: ExecutionTask
 ): Promise<ExecutionResult> {
@@ -198,11 +294,16 @@ export async function executeInSandbox(
     const exitCode = inspectInfo.State.ExitCode as number;
     console.log(`[sandbox] container completed: ${container.id} | exitCode: ${exitCode} | duration: ${(performance.now() - startTime).toFixed(2)}ms`);
 
+    const formattedStderr =
+      task.language === "cpp" && exitCode !== 0
+        ? formatCppCompilerErrors(stderr)
+        : stderr;
+
     return {
       taskId: task.id,
       status: exitCode === 0 ? "completed" : "failed",
       stdout,
-      stderr,
+      stderr: formattedStderr,
       exitCode,
       durationMs: performance.now() - startTime,
     };


### PR DESCRIPTION
## Description
Implements a custom compiler error formatter in the execution engine to convert verbose, multi-line raw C++ compiler (`g++`) traces into clean, structured Unicode boxed blocks.

Key changes:
1. Created `formatCppCompilerErrors` parser inside the execution sandbox logic.
2. Strips container-specific multiplexing header bytes and path names (`/tmp/main.cpp` -> `main.cpp`).
3. Highlights compiler errors, warnings, and notes with appropriate emojis and line/column annotations.
4. Frames code previews and caret pointer lines (`^~~`) under the respective error block for readability.
5. Hooked it into the C++ sandbox execution path to run automatically on runtime/compilation failure.

Fixes #36

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?
Created a mock validation script containing multiplexed Docker outputs of compiler errors, warnings, and notes.

### Automated Verification
- [x] `npm run typecheck` passes
- [x] `npm run build` passes

### Manual Verification
- [x] Verified through `verify-cpp-format.ts` that output parses accurately into boxed structures:
  👉 In function 'int main()':
  ┌── ❌ ERROR (Line 5, Col 5) ─────────────────────────────────────────────────────
  │  Message: 'cout' is not a member of 'std'
  │
  │      5 |     std::cout << "Hello" << std::endl;
  │        |     ^~~
  └──────────────────────────────────────────────────────────────────────────────

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My changes generate no new warnings or console errors.
