### PR TITLE
feat: Made multi-file workspace system with CRUD facility

### DIFF
--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -4,6 +4,7 @@ import type {
   ExecutionResult,
   SandboxConfig,
   SupportedLanguage,
+  ExecutionFile,
 } from "@tessera/shared-types";
 
 const docker = new Dockerode({ socketPath: "/var/run/docker.sock" });
@@ -16,15 +17,108 @@ const LANGUAGE_IMAGES: Record<SupportedLanguage, string> = {
   rust: "rust:1.75-slim",
 };
 
-const LANGUAGE_COMMANDS: Record<
-  SupportedLanguage,
-  (code: string) => string[]
-> = {
-  typescript: (code) => ["node", "--input-type=module", "-e", code],
-  python: (code) => ["python3", "-c", code],
-  cpp: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.cpp && g++ -o /tmp/main /tmp/main.cpp && /tmp/main`],
-  java: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/Main.java && javac /tmp/Main.java -d /tmp && java -cp /tmp Main`],
-  rust: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.rs && rustc /tmp/main.rs -o /tmp/main && /tmp/main`],
+// ─────────────────────────────────────────────────────────────
+// Shell-safe encoding
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Encode arbitrary text as a base64 string that can be safely
+ * embedded in a shell command and decoded with `base64 -d`.
+ * This sidesteps all quoting/escaping issues for file contents.
+ */
+function toBase64(text: string): string {
+  return Buffer.from(text, "utf-8").toString("base64");
+}
+
+/**
+ * Build a shell snippet that writes a single file into /tmp.
+ * Uses base64 to avoid any quoting issues with file contents.
+ */
+function writeFileSnippet(name: string, content: string): string {
+  const b64 = toBase64(content);
+  // Sanitise the filename: strip path traversal and keep only safe chars.
+  const safeName = name.replace(/[^a-zA-Z0-9._-]/g, "_");
+  return `echo '${b64}' | base64 -d > /tmp/${safeName}`;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Language command builders
+// ─────────────────────────────────────────────────────────────
+
+type CommandBuilder = (task: ExecutionTask) => string[];
+
+/**
+ * Build a shell command that:
+ *  1. Writes every workspace file into /tmp (including the entry-point).
+ *  2. Executes the entry-point with the appropriate runtime.
+ *
+ * All commands are joined with " && " so any write failure aborts early.
+ */
+function buildMultiFileCommand(
+  entrySnippet: string,
+  files: readonly ExecutionFile[],
+): string {
+  const writeSnippets = files.map((f) => writeFileSnippet(f.name, f.content));
+  const allSteps = [...writeSnippets, entrySnippet];
+  return allSteps.join(" && ");
+}
+
+const LANGUAGE_COMMANDS: Record<SupportedLanguage, CommandBuilder> = {
+  typescript: (task) => {
+    if (task.files.length <= 1) {
+      // Fast path: single-file, pass code directly.
+      return ["node", "--input-type=module", "-e", task.code];
+    }
+    const entry = task.files.find((f) => f.content === task.code)?.name ?? "main.ts";
+    const safeName = entry.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const runSnippet = `node --input-type=module /tmp/${safeName}`;
+    return ["sh", "-c", buildMultiFileCommand(runSnippet, task.files)];
+  },
+
+  python: (task) => {
+    if (task.files.length <= 1) {
+      return ["python3", "-c", task.code];
+    }
+    const entry = task.files.find((f) => f.content === task.code)?.name ?? "main.py";
+    const safeName = entry.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const runSnippet = `python3 /tmp/${safeName}`;
+    return ["sh", "-c", buildMultiFileCommand(runSnippet, task.files)];
+  },
+
+  cpp: (task) => {
+    if (task.files.length <= 1) {
+      const safe = task.code.replace(/'/g, "'\\''");
+      return ["sh", "-c", `echo '${safe}' > /tmp/main.cpp && g++ -o /tmp/main /tmp/main.cpp && /tmp/main`];
+    }
+    // Write all files, compile the entry, run.
+    const entry = task.files.find((f) => f.content === task.code)?.name ?? "main.cpp";
+    const safeName = entry.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const runSnippet = `g++ -o /tmp/main /tmp/${safeName} && /tmp/main`;
+    return ["sh", "-c", buildMultiFileCommand(runSnippet, task.files)];
+  },
+
+  java: (task) => {
+    if (task.files.length <= 1) {
+      const safe = task.code.replace(/'/g, "'\\''");
+      return ["sh", "-c", `echo '${safe}' > /tmp/Main.java && javac /tmp/Main.java -d /tmp && java -cp /tmp Main`];
+    }
+    const entry = task.files.find((f) => f.content === task.code)?.name ?? "Main.java";
+    const safeName = entry.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const className = safeName.replace(/\.java$/, "");
+    const runSnippet = `javac /tmp/${safeName} -d /tmp && java -cp /tmp ${className}`;
+    return ["sh", "-c", buildMultiFileCommand(runSnippet, task.files)];
+  },
+
+  rust: (task) => {
+    if (task.files.length <= 1) {
+      const safe = task.code.replace(/'/g, "'\\''");
+      return ["sh", "-c", `echo '${safe}' > /tmp/main.rs && rustc /tmp/main.rs -o /tmp/main && /tmp/main`];
+    }
+    const entry = task.files.find((f) => f.content === task.code)?.name ?? "main.rs";
+    const safeName = entry.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const runSnippet = `rustc /tmp/${safeName} -o /tmp/main && /tmp/main`;
+    return ["sh", "-c", buildMultiFileCommand(runSnippet, task.files)];
+  },
 };
 
 const DEFAULT_MEMORY_LIMIT_MB = 256;
@@ -75,7 +169,7 @@ export async function executeInSandbox(
   };
 
   const image = LANGUAGE_IMAGES[task.language];
-  const cmd = LANGUAGE_COMMANDS[task.language](task.code);
+  const cmd = LANGUAGE_COMMANDS[task.language](task);
 
   let container: Dockerode.Container | undefined;
 

--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -180,6 +180,16 @@ const LANGUAGE_COMMANDS: Record<SupportedLanguage, CommandBuilder> = {
     const runSnippet = `rustc /tmp/${safeName} -o /tmp/main && /tmp/main`;
     return ["sh", "-c", buildMultiFileCommand(runSnippet, task.files)];
   },
+  go: (task) => {
+    if (task.files.length <= 1) {
+      const safe = task.code.replace(/'/g, "'\\''");
+      return ["sh", "-c", `echo '${safe}' > /tmp/main.go && go run /tmp/main.go`];
+    }
+    const entry = task.files.find((f) => f.content === task.code)?.name ?? "main.go";
+    const safeName = entry.replace(/[^a-zA-Z0-9._-]/g, "_");
+    const runSnippet = `go run /tmp/${safeName}`;
+    return ["sh", "-c", buildMultiFileCommand(runSnippet, task.files)];
+  },
 };
 
 const DEFAULT_MEMORY_LIMIT_MB = 256;

--- a/apps/sync-server/src/server.ts
+++ b/apps/sync-server/src/server.ts
@@ -143,9 +143,10 @@ io.on("connection", (socket) => {
         timeoutMs: 5000,
         roomId: currentRoomId,
         createdAt: new Date().toISOString(),
+        files: payload.files ?? [],
       };
 
-      console.log(`[sync-server] enqueuing code execution ${taskId} [lang=${payload.language}]`);
+      console.log(`[sync-server] enqueuing code execution ${taskId} [lang=${payload.language}, files=${String(task.files.length)}]`);
       const job = await executionQueue.add("execute", task, { jobId: taskId });
       
       const result = await job.waitUntilFinished(queueEvents);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,28 +1,21 @@
 import { useMemo, useState, useEffect } from "react";
 import { SidePanel } from "@tessera/ui-components";
 import { CollaborativeEditor } from "./components/CollaborativeEditor.js";
+import { FileExplorer } from "./components/FileExplorer.js";
+import { FileIcon } from "./components/FileIcon.js";
 import {
   useCollaboration,
   createDefaultParticipant,
 } from "./hooks/useCollaboration.js";
-import { isMacOS, getExecutionShortcutText } from "./utils/platformDetection.js";
-import type { SyncConnectionConfig, SupportedLanguage, ExecutionResult } from "@tessera/shared-types";
+import { useWorkspace } from "./hooks/useWorkspace.js";
+import type { SyncConnectionConfig, ExecutionResult, ExecutionFile } from "@tessera/shared-types";
 import { downloadTextFile } from "./utils/downloadUtils.js";
 
 const SYNC_SERVER_URL = "http://localhost:4000";
 const DEFAULT_ROOM = "default-room";
 
-const FILE_NAMES: Record<SupportedLanguage, string> = {
-  typescript: "main.ts",
-  python: "main.py",
-  cpp: "main.cpp",
-  java: "Main.java",
-  rust: "main.rs"
-};
-
 export function App() {
   const participant = useMemo(() => createDefaultParticipant(), []);
-  const [language, setLanguage] = useState<SupportedLanguage>("typescript");
   const [isRunning, setIsRunning] = useState(false);
   const [isAiPanelOpen, setIsAiPanelOpen] = useState(false);
   const [output, setOutput] = useState<ExecutionResult | null>(null);
@@ -38,88 +31,127 @@ export function App() {
     [participant],
   );
 
-  const { ytext, awareness, connected, socket } = useCollaboration(config);
+  const { ydoc, yworkspace, awareness, connected, socket } = useCollaboration(config);
 
+  const {
+    files,
+    folders,
+    activeFileId,
+    setActiveFileId,
+    activeYText,
+    createFile,
+    createFolder,
+    renameFile,
+    renameFolder,
+    deleteFile,
+    deleteFolder,
+    getYText,
+  } = useWorkspace(ydoc, yworkspace);
+
+  // Derive language from the active file's extension.
+  const activeFile = files.find((f) => f.id === activeFileId) ?? null;
+  const activeLanguage = activeFile?.language ?? "typescript";
+
+  // Derive Monaco editor language from file name to support plaintext/json/csv
+  const editorLanguage = useMemo(() => {
+    if (!activeFile) return "plaintext";
+    const ext = activeFile.name.split(".").pop()?.toLowerCase() ?? "";
+    switch (ext) {
+      case "ts":
+      case "tsx":
+      case "js":
+      case "jsx":
+        return "typescript";
+      case "py":
+        return "python";
+      case "cpp":
+      case "cc":
+      case "cxx":
+      case "h":
+      case "hpp":
+        return "cpp";
+      case "java":
+        return "java";
+      case "rs":
+        return "rust";
+      case "json":
+        return "json";
+      case "md":
+        return "markdown";
+      case "csv":
+      case "txt":
+      case "log":
+        return "plaintext";
+      default:
+        return "plaintext";
+    }
+  }, [activeFile]);
+
+  // ── Execution result handler ────────────────────────────────
   useEffect(() => {
     if (!socket) return;
-
-    const handleExecutionResult = (result: ExecutionResult) => {
+    const handleResult = (result: ExecutionResult) => {
       setOutput(result);
       setIsRunning(false);
     };
-
-    socket.on("execution-result", handleExecutionResult);
-
-    return () => {
-      socket.off("execution-result", handleExecutionResult);
-    };
+    socket.on("execution-result", handleResult);
+    return () => { socket.off("execution-result", handleResult); };
   }, [socket]);
 
-  useEffect(() => {
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const isExecutionShortcut = isMacOS() ? event.metaKey : event.ctrlKey;
-      if (isExecutionShortcut && event.key === "Enter") {
-        event.preventDefault();
-        if (!isRunning && connected) {
-          handleRunCode();
-        }
-      }
-    };
-
-    window.addEventListener("keydown", handleKeyDown);
-    return () => window.removeEventListener("keydown", handleKeyDown);
-  }, [socket, ytext, isRunning, connected]);
+  // ── Run code ───────────────────────────────────────────────
 
   const handleRunCode = () => {
-    if (!socket || !ytext || isRunning) return;
+    if (!socket || !activeYText || !activeFile || isRunning) return;
     setIsRunning(true);
     setOutput(null);
+
+    // Collect all workspace files for the sandbox.
+    const allFiles: ExecutionFile[] = files.map((f) => ({
+      name: f.name,
+      content: getYText(f.id)?.toString() ?? "",
+    }));
+
     socket.emit("execute-code", {
-      code: ytext.toString(),
-      language,
+      code: activeYText.toString(),
+      language: activeLanguage,
+      files: allFiles,
     });
   };
 
+  // ── Download active file ───────────────────────────────────
   const handleDownload = () => {
-    if (!ytext) return;
-    downloadTextFile(ytext.toString(), FILE_NAMES[language]);
+    if (!activeYText || !activeFile) return;
+    downloadTextFile(activeYText.toString(), activeFile.name);
   };
+
   return (
     <div className="flex h-screen flex-col bg-[var(--color-bg)]">
-      {/* Header */}
+      {/* ── Header ─────────────────────────────────────────────── */}
       <header className="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2 bg-[var(--color-surface)]">
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-3">
           <h1 className="text-lg font-semibold tracking-tight text-white">
             Tessera<span className="text-tessera-500">.io</span>
           </h1>
+          {/* Active file breadcrumb */}
+          {activeFile && (
+            <span className="flex items-center gap-1.5 text-xs text-slate-500 font-mono">
+              /
+              <FileIcon filename={activeFile.name} className="h-3.5 w-3.5" />
+              <span className="text-slate-300">{activeFile.name}</span>
+            </span>
+          )}
         </div>
 
-        <div className="flex items-center gap-4">
-          {/* Language Selector */}
-          <div className="flex items-center gap-2">
-            <span className="text-xs text-slate-400">Language:</span>
-            <select
-              value={language}
-              onChange={(e) => setLanguage(e.target.value as SupportedLanguage)}
-              className="bg-[var(--color-bg)] text-sm text-white border border-[var(--color-border)] rounded px-2 py-1 focus:outline-none focus:border-tessera-500 font-medium"
-            >
-              <option value="typescript">TypeScript</option>
-              <option value="python">Python</option>
-              <option value="cpp">C++</option>
-              <option value="java">Java</option>
-              <option value="rust">Rust</option>
-            </select>
-          </div>
-
+        <div className="flex items-center gap-3">
           {/* Run Button */}
           <button
+            id="run-code-btn"
             onClick={handleRunCode}
-            disabled={!connected || isRunning}
-            title={`Run code (${getExecutionShortcutText()})`}
+            disabled={!connected || isRunning || !activeFile}
             className={`flex items-center gap-1.5 px-3 py-1 text-sm font-semibold rounded transition shadow-sm ${
               isRunning
                 ? "bg-slate-700 text-slate-400 cursor-not-allowed"
-                : !connected
+                : !connected || !activeFile
                 ? "bg-slate-800 text-slate-500 cursor-not-allowed"
                 : "bg-tessera-600 hover:bg-tessera-500 text-white cursor-pointer active:scale-95"
             }`}
@@ -130,7 +162,7 @@ export function App() {
                   <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
                   <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
                 </svg>
-                Running...
+                Running…
               </>
             ) : (
               <>
@@ -138,18 +170,23 @@ export function App() {
               </>
             )}
           </button>
+
           {/* Download Button */}
           <button
+            id="download-btn"
             onClick={handleDownload}
-            disabled={!ytext}
+            disabled={!activeYText}
             className="flex items-center justify-center p-1.5 text-slate-400 hover:text-white hover:bg-[var(--color-bg)] rounded transition"
-            title={`Download ${FILE_NAMES[language]}`}>
+            title={`Download ${activeFile?.name ?? "file"}`}
+          >
             <svg className="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4" />
             </svg>
           </button>
 
+          {/* AI Panel */}
           <button
+            id="ai-panel-btn"
             type="button"
             onClick={() => setIsAiPanelOpen(true)}
             className="rounded border border-[var(--color-border)] bg-[var(--color-bg)] px-3 py-1 text-sm font-semibold text-slate-200 transition hover:border-tessera-500 hover:text-white focus:outline-none focus:ring-2 focus:ring-tessera-500"
@@ -158,7 +195,7 @@ export function App() {
           </button>
 
           {/* Connection Indicator */}
-          <div className="flex items-center gap-2 border-l border-[var(--color-border)] pl-4">
+          <div className="flex items-center gap-2 border-l border-[var(--color-border)] pl-3">
             <span
               className={`inline-block h-2 w-2 rounded-full ${connected ? "bg-emerald-400" : "bg-red-400 animate-pulse"}`}
             />
@@ -169,22 +206,28 @@ export function App() {
         </div>
       </header>
 
-      {/* Main content */}
+      {/* ── Main content ───────────────────────────────────────── */}
       <div className="flex flex-1 overflow-hidden">
-        {/* Sidebar */}
-        <aside className="w-56 shrink-0 border-r border-[var(--color-border)] bg-[var(--color-surface)] p-3 flex flex-col justify-between">
-          <div>
-            <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
-              Explorer
-            </p>
-            <div className="mt-3 space-y-1">
-              <div className="rounded px-2 py-1 text-sm font-medium text-tessera-400 bg-tessera-500/10 border border-tessera-500/20">
-                📄 {FILE_NAMES[language]}
-              </div>
-            </div>
+        {/* Sidebar — File Explorer */}
+        <aside className="w-56 shrink-0 border-r border-[var(--color-border)] bg-[var(--color-surface)] flex flex-col overflow-hidden">
+          {/* Explorer tree */}
+          <div className="flex-1 overflow-hidden p-2">
+            <FileExplorer
+              files={files}
+              folders={folders}
+              activeFileId={activeFileId}
+              onSelectFile={setActiveFileId}
+              onCreateFile={createFile}
+              onCreateFolder={createFolder}
+              onRenameFile={renameFile}
+              onRenameFolder={renameFolder}
+              onDeleteFile={deleteFile}
+              onDeleteFolder={deleteFolder}
+            />
           </div>
 
-          <div className="border-t border-[var(--color-border)] pt-4">
+          {/* Editor Settings — pinned to bottom */}
+          <div className="border-t border-[var(--color-border)] p-3 flex-shrink-0">
             <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 mb-3">
               Editor Settings
             </p>
@@ -201,7 +244,7 @@ export function App() {
                     onChange={(e) => setShowMinimap(e.target.checked)}
                     className="sr-only peer"
                   />
-                  <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600 cursor-pointer"></div>
+                  <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600 cursor-pointer" />
                 </div>
               </div>
 
@@ -209,7 +252,8 @@ export function App() {
                 <span className="text-xs font-medium text-slate-300">Font Size</span>
                 <div className="flex items-center gap-1.5">
                   <button
-                    onClick={() => setFontSize((prev) => Math.max(10, prev - 1))}
+                    id="font-decrease-btn"
+                    onClick={() => setFontSize((p) => Math.max(10, p - 1))}
                     disabled={fontSize <= 10}
                     className="w-6 h-6 flex items-center justify-center rounded border border-[var(--color-border)] bg-[var(--color-bg)] text-xs text-slate-300 hover:text-white hover:border-tessera-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-[var(--color-border)] disabled:hover:text-slate-300 select-none transition-all active:scale-95"
                   >
@@ -219,7 +263,8 @@ export function App() {
                     {fontSize}px
                   </span>
                   <button
-                    onClick={() => setFontSize((prev) => Math.min(24, prev + 1))}
+                    id="font-increase-btn"
+                    onClick={() => setFontSize((p) => Math.min(24, p + 1))}
                     disabled={fontSize >= 24}
                     className="w-6 h-6 flex items-center justify-center rounded border border-[var(--color-border)] bg-[var(--color-bg)] text-xs text-slate-300 hover:text-white hover:border-tessera-500 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:border-[var(--color-border)] disabled:hover:text-slate-300 select-none transition-all active:scale-95"
                   >
@@ -233,11 +278,11 @@ export function App() {
 
         {/* Editor */}
         <main className="flex-1 overflow-hidden">
-          {ytext && awareness ? (
+          {activeYText && awareness ? (
             <CollaborativeEditor
-              ytext={ytext}
+              ytext={activeYText}
               awareness={awareness}
-              language={language}
+              language={editorLanguage}
               showMinimap={showMinimap}
               fontSize={fontSize}
             />
@@ -253,7 +298,7 @@ export function App() {
         </main>
       </div>
 
-      {/* Output panel */}
+      {/* ── Output panel ───────────────────────────────────────── */}
       <div className="h-56 shrink-0 border-t border-[var(--color-border)] bg-[var(--color-surface)] flex flex-col p-3 overflow-hidden">
         <div className="flex items-center justify-between border-b border-[var(--color-border)] pb-2 mb-2">
           <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
@@ -264,9 +309,7 @@ export function App() {
               <span className={output.status === "completed" ? "text-emerald-400" : "text-rose-400"}>
                 Status: {output.status}
               </span>
-              <span className="text-slate-400">
-                Duration: {output.durationMs}ms
-              </span>
+              <span className="text-slate-400">Duration: {output.durationMs}ms</span>
               {output.exitCode !== null && (
                 <span className={output.exitCode === 0 ? "text-emerald-400" : "text-rose-400"}>
                   Exit Code: {output.exitCode}
@@ -277,23 +320,28 @@ export function App() {
         </div>
         <div className="flex-1 overflow-y-auto font-mono text-xs p-2 rounded bg-[var(--color-bg)] border border-[var(--color-border)]">
           {isRunning ? (
-            <span className="text-tessera-400 animate-pulse">Running execution sandbox...</span>
+            <span className="text-tessera-400 animate-pulse">Running execution sandbox…</span>
           ) : output ? (
             <div className="space-y-1 whitespace-pre-wrap">
               {output.stdout && <div className="text-emerald-300">{output.stdout}</div>}
               {output.stderr && <div className="text-rose-400 font-semibold">{output.stderr}</div>}
-              {!output.stdout && !output.stderr && <div className="text-slate-500 italic">No output returned (Process completed with exit code {output.exitCode}).</div>}
+              {!output.stdout && !output.stderr && (
+                <div className="text-slate-500 italic">
+                  No output returned (Process completed with exit code {output.exitCode}).
+                </div>
+              )}
             </div>
           ) : (
-            <span className="text-slate-500">Ready to execute. Write some code and click "Run".</span>
+            <span className="text-slate-500">Ready to execute. Open a file and click "Run".</span>
           )}
         </div>
       </div>
 
+      {/* ── AI Side Panel ──────────────────────────────────────── */}
       <SidePanel
         open={isAiPanelOpen}
         title="AI Chat"
-        description={`Context: ${FILE_NAMES[language]}`}
+        description={`Context: ${activeFile?.name ?? "no file"}`}
         onClose={() => setIsAiPanelOpen(false)}
       >
         <div className="rounded border border-dashed border-[var(--color-border)] bg-[var(--color-bg)] p-4 text-sm text-slate-400">

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,6 +14,7 @@ import { downloadTextFile } from "./utils/downloadUtils.js";
 const SYNC_SERVER_URL = "http://localhost:4000";
 const DEFAULT_ROOM = "default-room";
 
+
 export function App() {
   const participant = useMemo(() => createDefaultParticipant(), []);
   const [isRunning, setIsRunning] = useState(false);
@@ -50,7 +51,6 @@ export function App() {
 
   // Derive language from the active file's extension.
   const activeFile = files.find((f) => f.id === activeFileId) ?? null;
-  const activeLanguage = activeFile?.language ?? "typescript";
 
   // Derive Monaco editor language from file name to support plaintext/json/csv
   const editorLanguage = useMemo(() => {

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -14,7 +14,6 @@ import { downloadTextFile } from "./utils/downloadUtils.js";
 const SYNC_SERVER_URL = "http://localhost:4000";
 const DEFAULT_ROOM = "default-room";
 
-
 export function App() {
   const participant = useMemo(() => createDefaultParticipant(), []);
   const [isRunning, setIsRunning] = useState(false);
@@ -74,6 +73,8 @@ export function App() {
         return "java";
       case "rs":
         return "rust";
+      case "go":
+        return "go";
       case "json":
         return "json";
       case "md":
@@ -113,7 +114,7 @@ export function App() {
 
     socket.emit("execute-code", {
       code: activeYText.toString(),
-      language: activeLanguage,
+      language: editorLanguage,
       files: allFiles,
     });
   };
@@ -248,7 +249,7 @@ export function App() {
                     className="sr-only peer"
                   />
                   <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600 cursor-pointer" />
-                </div>
+                </label>
               </div>
 
               <div className="flex items-center justify-between">
@@ -335,7 +336,7 @@ export function App() {
               )}
             </div>
           ) : (
-            <span className="text-slate-500">Ready to execute. Open a file and click "Run".</span>
+            <span className="text-slate-500">Ready to execute. Open a file and click &quot;Run&quot;.</span>
           )}
         </div>
       </div>

--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -4,24 +4,14 @@ import { MonacoBinding } from "y-monaco";
 import type * as Y from "yjs";
 import type { Awareness } from "y-protocols/awareness";
 import type { editor } from "monaco-editor";
-import type { SupportedLanguage } from "@tessera/shared-types";
-import { registerEditorIntelliSense } from "../intellisense/index.js";
 
 interface CollaborativeEditorProps {
   readonly ytext: Y.Text;
   readonly awareness: Awareness;
-  readonly language?: SupportedLanguage;
+  readonly language?: string;
   readonly showMinimap?: boolean;
   readonly fontSize?: number;
 }
-
-const LANGUAGE_MAP: Record<SupportedLanguage, string> = {
-  typescript: "typescript",
-  python: "python",
-  cpp: "cpp",
-  java: "java",
-  rust: "rust"
-};
 
 export function CollaborativeEditor({
   ytext,
@@ -33,24 +23,43 @@ export function CollaborativeEditor({
   const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
   const bindingRef = useRef<MonacoBinding | null>(null);
 
-  const handleEditorMount: OnMount = useCallback(
-    (mountedEditor, monaco) => {
-      editorRef.current = mountedEditor;
-      registerEditorIntelliSense(monaco);
+  /** Recreate the Monaco–Yjs binding whenever the active ytext changes. */
+  const rebind = useCallback(
+    (editorInstance: editor.IStandaloneCodeEditor) => {
+      // Destroy any previous binding first.
+      bindingRef.current?.destroy();
+      bindingRef.current = null;
 
-      const model = mountedEditor.getModel();
+
+      const model = editorInstance.getModel();
       if (!model) return;
 
       bindingRef.current = new MonacoBinding(
         ytext,
         model,
-        new Set([mountedEditor]),
+        new Set([editorInstance]),
         awareness,
       );
     },
     [ytext, awareness],
   );
 
+  const handleEditorMount: OnMount = useCallback(
+    (mountedEditor) => {
+      editorRef.current = mountedEditor;
+      rebind(mountedEditor);
+    },
+    [rebind],
+  );
+
+  // Re-bind whenever the active file (ytext) changes after initial mount.
+  useEffect(() => {
+    if (editorRef.current) {
+      rebind(editorRef.current);
+    }
+  }, [rebind]);
+
+  // Cleanup on unmount.
   useEffect(() => {
     return () => {
       bindingRef.current?.destroy();
@@ -59,23 +68,17 @@ export function CollaborativeEditor({
   }, []);
 
   useEffect(() => {
-    if (editorRef.current) {
-      editorRef.current.updateOptions({
-        minimap: { enabled: showMinimap },
-      });
-    }
+    editorRef.current?.updateOptions({ minimap: { enabled: showMinimap } });
   }, [showMinimap]);
 
   useEffect(() => {
-    if (editorRef.current) {
-      editorRef.current.updateOptions({ fontSize });
-    }
+    editorRef.current?.updateOptions({ fontSize });
   }, [fontSize]);
 
   return (
     <Editor
       height="100%"
-      language={LANGUAGE_MAP[language]}
+      language={language}
       theme="vs-dark"
       onMount={handleEditorMount}
       options={{

--- a/apps/web/src/components/FileExplorer.tsx
+++ b/apps/web/src/components/FileExplorer.tsx
@@ -1,0 +1,435 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import type { WorkspaceFile, WorkspaceFolder } from "@tessera/shared-types";
+import { FileIcon } from "./FileIcon.js";
+
+// ─────────────────────────────────────────────────────────────
+// Icons
+// ─────────────────────────────────────────────────────────────
+
+function IconFile({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor">
+      <path d="M9 1H3a1 1 0 0 0-1 1v12a1 1 0 0 0 1 1h10a1 1 0 0 0 1-1V5l-5-4zm-1 4V2l4 4H8V5z" />
+    </svg>
+  );
+}
+
+function IconFolder({ open, className }: { open?: boolean; className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="currentColor">
+      {open ? (
+        <path d="M1.5 3h4.44l1.56 1.5H14.5a.5.5 0 0 1 .5.5v8a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5V3.5a.5.5 0 0 1 .5-.5z" />
+      ) : (
+        <path d="M1.5 3h4.44l1.56 1.5H14.5a.5.5 0 0 1 .5.5v7.5a.5.5 0 0 1-.5.5h-13a.5.5 0 0 1-.5-.5v-9A.5.5 0 0 1 1.5 3z" />
+      )}
+    </svg>
+  );
+}
+
+function IconPencil({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M11 2l3 3-8 8H3v-3l8-8z" />
+    </svg>
+  );
+}
+
+function IconTrash({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.5">
+      <path strokeLinecap="round" strokeLinejoin="round" d="M2 4h12M5 4V2h6v2M6 7v5M10 7v5M3 4l1 9h8l1-9" />
+    </svg>
+  );
+}
+
+function IconChevron({ open, className }: { open: boolean; className?: string }) {
+  return (
+    <svg
+      className={`${className ?? ""} transition-transform duration-200 ${open ? "rotate-90" : ""}`}
+      viewBox="0 0 16 16"
+      fill="currentColor"
+    >
+      <path d="M6 4l4 4-4 4V4z" />
+    </svg>
+  );
+}
+
+function IconPlus({ className }: { className?: string }) {
+  return (
+    <svg className={className} viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2">
+      <path strokeLinecap="round" d="M8 3v10M3 8h10" />
+    </svg>
+  );
+}
+
+// File icons are loaded from FileIcon.tsx
+
+// ─────────────────────────────────────────────────────────────
+// Inline rename input
+// ─────────────────────────────────────────────────────────────
+
+interface RenameInputProps {
+  initialValue: string;
+  onCommit(name: string): void;
+  onCancel(): void;
+}
+
+function RenameInput({ initialValue, onCommit, onCancel }: RenameInputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    ref.current?.select();
+  }, []);
+
+  return (
+    <input
+      ref={ref}
+      defaultValue={initialValue}
+      className="flex-1 min-w-0 bg-[var(--color-bg)] border border-tessera-500 rounded px-1 text-xs text-white outline-none"
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          const v = ref.current?.value.trim();
+          if (v) onCommit(v);
+        } else if (e.key === "Escape") {
+          onCancel();
+        }
+      }}
+      onBlur={() => {
+        const v = ref.current?.value.trim();
+        if (v) onCommit(v);
+        else onCancel();
+      }}
+    />
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// New-item input (inline at the bottom of a section)
+// ─────────────────────────────────────────────────────────────
+
+interface NewItemInputProps {
+  placeholder: string;
+  onCommit(name: string): void;
+  onCancel(): void;
+}
+
+function NewItemInput({ placeholder, onCommit, onCancel }: NewItemInputProps) {
+  const ref = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    ref.current?.focus();
+  }, []);
+
+  return (
+    <div className="flex items-center gap-1 px-2 py-1">
+      <input
+        ref={ref}
+        placeholder={placeholder}
+        className="flex-1 min-w-0 bg-[var(--color-bg)] border border-tessera-500/70 rounded px-1.5 py-0.5 text-xs text-white outline-none placeholder-slate-600 focus:border-tessera-500"
+        onKeyDown={(e) => {
+          if (e.key === "Enter") {
+            const v = ref.current?.value.trim();
+            if (v) onCommit(v);
+          } else if (e.key === "Escape") {
+            onCancel();
+          }
+        }}
+        onBlur={() => {
+          const v = ref.current?.value.trim();
+          if (v) onCommit(v);
+          else onCancel();
+        }}
+      />
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// FileRow
+// ─────────────────────────────────────────────────────────────
+
+interface FileRowProps {
+  file: WorkspaceFile;
+  isActive: boolean;
+  indent?: boolean;
+  onSelect(): void;
+  onRename(newName: string): void;
+  onDelete(): void;
+}
+
+function FileRow({ file, isActive, indent, onSelect, onRename, onDelete }: FileRowProps) {
+  const [renaming, setRenaming] = useState(false);
+
+  return (
+    <div
+      className={`group flex items-center gap-1.5 rounded px-2 py-1 cursor-pointer text-xs transition-colors select-none
+        ${isActive
+          ? "bg-tessera-500/15 text-tessera-300 border border-tessera-500/25"
+          : "text-slate-400 hover:bg-white/5 hover:text-slate-200 border border-transparent"
+        }
+        ${indent ? "ml-4" : ""}`}
+      onClick={() => { if (!renaming) onSelect(); }}
+      onDoubleClick={() => setRenaming(true)}
+    >
+      <FileIcon filename={file.name} className="h-3.5 w-3.5 flex-shrink-0" />
+
+      {renaming ? (
+        <RenameInput
+          initialValue={file.name}
+          onCommit={(n) => { onRename(n); setRenaming(false); }}
+          onCancel={() => setRenaming(false)}
+        />
+      ) : (
+        <span className="flex-1 truncate font-medium">{file.name}</span>
+      )}
+
+      {!renaming && (
+        <span className="hidden group-hover:flex items-center gap-1 ml-auto flex-shrink-0">
+          <button
+            className="p-0.5 rounded hover:text-tessera-400 transition-colors"
+            title="Rename"
+            onClick={(e) => { e.stopPropagation(); setRenaming(true); }}
+          >
+            <IconPencil className="h-3 w-3" />
+          </button>
+          <button
+            className="p-0.5 rounded hover:text-rose-400 transition-colors"
+            title="Delete"
+            onClick={(e) => { e.stopPropagation(); onDelete(); }}
+          >
+            <IconTrash className="h-3 w-3" />
+          </button>
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// FolderRow
+// ─────────────────────────────────────────────────────────────
+
+interface FolderRowProps {
+  folder: WorkspaceFolder;
+  isOpen: boolean;
+  onToggle(): void;
+  onRename(newName: string): void;
+  onDelete(): void;
+}
+
+function FolderRow({ folder, isOpen, onToggle, onRename, onDelete }: FolderRowProps) {
+  const [renaming, setRenaming] = useState(false);
+
+  return (
+    <div
+      className="group flex items-center gap-1.5 rounded px-2 py-1 cursor-pointer text-xs text-slate-300 hover:bg-white/5 hover:text-slate-100 transition-colors select-none border border-transparent"
+      onClick={() => { if (!renaming) onToggle(); }}
+      onDoubleClick={() => setRenaming(true)}
+    >
+      <IconChevron open={isOpen} className="h-3 w-3 flex-shrink-0 opacity-60" />
+      <IconFolder open={isOpen} className="h-3.5 w-3.5 flex-shrink-0 text-yellow-400/80" />
+
+      {renaming ? (
+        <RenameInput
+          initialValue={folder.name}
+          onCommit={(n) => { onRename(n); setRenaming(false); }}
+          onCancel={() => setRenaming(false)}
+        />
+      ) : (
+        <span className="flex-1 truncate font-medium">{folder.name}</span>
+      )}
+
+      {!renaming && (
+        <span className="hidden group-hover:flex items-center gap-1 ml-auto flex-shrink-0">
+          <button
+            className="p-0.5 rounded hover:text-tessera-400 transition-colors"
+            title="Rename"
+            onClick={(e) => { e.stopPropagation(); setRenaming(true); }}
+          >
+            <IconPencil className="h-3 w-3" />
+          </button>
+          <button
+            className="p-0.5 rounded hover:text-rose-400 transition-colors"
+            title="Delete folder and its files"
+            onClick={(e) => { e.stopPropagation(); onDelete(); }}
+          >
+            <IconTrash className="h-3 w-3" />
+          </button>
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// FileExplorer
+// ─────────────────────────────────────────────────────────────
+
+export interface FileExplorerProps {
+  files: readonly WorkspaceFile[];
+  folders: readonly WorkspaceFolder[];
+  activeFileId: string | null;
+  onSelectFile(id: string): void;
+  onCreateFile(name: string, parentFolderId?: string | null): void;
+  onCreateFolder(name: string): void;
+  onRenameFile(id: string, newName: string): void;
+  onRenameFolder(id: string, newName: string): void;
+  onDeleteFile(id: string): void;
+  onDeleteFolder(id: string): void;
+}
+
+type CreatingState =
+  | { type: "file"; parentFolderId: string | null }
+  | { type: "folder" }
+  | null;
+
+export function FileExplorer({
+  files,
+  folders,
+  activeFileId,
+  onSelectFile,
+  onCreateFile,
+  onCreateFolder,
+  onRenameFile,
+  onRenameFolder,
+  onDeleteFile,
+  onDeleteFolder,
+}: FileExplorerProps) {
+  const [openFolders, setOpenFolders] = useState<Set<string>>(new Set());
+  const [creating, setCreating] = useState<CreatingState>(null);
+
+  const toggleFolder = useCallback((id: string) => {
+    setOpenFolders((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const rootFiles = files.filter((f) => f.parentFolderId === null);
+
+  return (
+    <div className="flex flex-col h-full overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-2 pb-2 border-b border-[var(--color-border)] mb-2">
+        <p className="text-xs font-semibold uppercase tracking-wider text-slate-500">
+          Explorer
+        </p>
+        <div className="flex items-center gap-1">
+          <button
+            id="new-file-btn"
+            className="p-1 rounded hover:bg-white/10 text-slate-400 hover:text-white transition-colors"
+            title="New File"
+            onClick={() => setCreating({ type: "file", parentFolderId: null })}
+          >
+            <IconFile className="h-3.5 w-3.5" />
+          </button>
+          <button
+            id="new-folder-btn"
+            className="p-1 rounded hover:bg-white/10 text-slate-400 hover:text-white transition-colors"
+            title="New Folder"
+            onClick={() => setCreating({ type: "folder" })}
+          >
+            <IconFolder className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+
+      {/* Tree */}
+      <div className="flex-1 overflow-y-auto space-y-0.5 pr-1">
+        {/* Root-level files */}
+        {rootFiles.map((file) => (
+          <FileRow
+            key={file.id}
+            file={file}
+            isActive={file.id === activeFileId}
+            onSelect={() => onSelectFile(file.id)}
+            onRename={(n) => onRenameFile(file.id, n)}
+            onDelete={() => onDeleteFile(file.id)}
+          />
+        ))}
+
+        {/* New root file input */}
+        {creating?.type === "file" && creating.parentFolderId === null && (
+          <NewItemInput
+            placeholder="filename.py"
+            onCommit={(n) => { onCreateFile(n, null); setCreating(null); }}
+            onCancel={() => setCreating(null)}
+          />
+        )}
+
+        {/* Folders */}
+        {folders.map((folder) => {
+          const isOpen = openFolders.has(folder.id);
+          const folderFiles = files.filter((f) => f.parentFolderId === folder.id);
+
+          return (
+            <div key={folder.id}>
+              <FolderRow
+                folder={folder}
+                isOpen={isOpen}
+                onToggle={() => toggleFolder(folder.id)}
+                onRename={(n) => onRenameFolder(folder.id, n)}
+                onDelete={() => onDeleteFolder(folder.id)}
+              />
+
+              {/* Folder contents */}
+              {isOpen && (
+                <div className="mt-0.5 space-y-0.5">
+                  {folderFiles.map((file) => (
+                    <FileRow
+                      key={file.id}
+                      file={file}
+                      isActive={file.id === activeFileId}
+                      indent
+                      onSelect={() => onSelectFile(file.id)}
+                      onRename={(n) => onRenameFile(file.id, n)}
+                      onDelete={() => onDeleteFile(file.id)}
+                    />
+                  ))}
+
+                  {/* New file inside folder */}
+                  {creating?.type === "file" &&
+                    creating.parentFolderId === folder.id && (
+                      <NewItemInput
+                        placeholder="filename.py"
+                        onCommit={(n) => { onCreateFile(n, folder.id); setCreating(null); }}
+                        onCancel={() => setCreating(null)}
+                      />
+                    )}
+
+                  {/* Add file to folder button */}
+                  <button
+                    className="ml-4 flex items-center gap-1 px-2 py-0.5 text-xs text-slate-600 hover:text-slate-400 transition-colors"
+                    onClick={() => setCreating({ type: "file", parentFolderId: folder.id })}
+                  >
+                    <IconPlus className="h-2.5 w-2.5" /> Add file
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+
+        {/* New folder input */}
+        {creating?.type === "folder" && (
+          <NewItemInput
+            placeholder="folder-name"
+            onCommit={(n) => { onCreateFolder(n); setCreating(null); }}
+            onCancel={() => setCreating(null)}
+          />
+        )}
+
+        {/* Empty state */}
+        {files.length === 0 && folders.length === 0 && !creating && (
+          <div className="px-2 py-4 text-center text-xs text-slate-600">
+            No files yet.
+            <br />
+            Click the icons above to get started.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/FileIcon.tsx
+++ b/apps/web/src/components/FileIcon.tsx
@@ -1,0 +1,91 @@
+export interface FileIconProps {
+  filename: string;
+  className?: string;
+}
+
+export function FileIcon({ filename, className }: FileIconProps) {
+  const ext = filename.split(".").pop()?.toLowerCase() ?? "";
+  switch (ext) {
+    case "ts":
+    case "tsx":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className ?? "h-3.5 w-3.5 flex-shrink-0"}>
+          <rect width="16" height="16" rx="2.5" fill="#3178C6" />
+          <text x="14.5" y="13" fill="white" fontSize="8" fontFamily="system-ui, -apple-system, sans-serif" fontWeight="800" textAnchor="end">TS</text>
+        </svg>
+      );
+    case "js":
+    case "jsx":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className ?? "h-3.5 w-3.5 flex-shrink-0"}>
+          <rect width="16" height="16" rx="2.5" fill="#F7DF1E" />
+          <text x="14.5" y="13" fill="black" fontSize="8" fontFamily="system-ui, -apple-system, sans-serif" fontWeight="800" textAnchor="end">JS</text>
+        </svg>
+      );
+    case "py":
+      return (
+        <svg viewBox="0 0 16 16" className={className ?? "h-3.5 w-3.5 flex-shrink-0"}>
+          <path d="M8 0A4 4 0 0 0 4 4v1h4v1H3a3 3 0 0 0-3 3v3a3 3 0 0 0 3 3h1v-1a2 2 0 0 1 2-2h4a2 2 0 0 0 2-2V7a3 3 0 0 0-3-3H9V3a1 1 0 0 1 1-1h1V0H8z" fill="#3776AB" />
+          <path d="M8 16a4 4 0 0 0 4-4v-1H8v-1h5a3 3 0 0 0 3-3V4a3 3 0 0 0-3-3h-1v1a2 2 0 0 1-2 2H6a2 2 0 0 0-2 2v3a3 3 0 0 0 3 3h2v1a1 1 0 0 1-1 1H5v2h3z" fill="#FFD343" />
+        </svg>
+      );
+    case "cpp":
+    case "cc":
+    case "cxx":
+    case "h":
+    case "hpp":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className ?? "h-3.5 w-3.5 flex-shrink-0"}>
+          <rect width="16" height="16" rx="2.5" fill="#00599C" />
+          <text x="8" y="11" fill="white" fontSize="7" fontFamily="system-ui, -apple-system, sans-serif" fontWeight="800" textAnchor="middle">C++</text>
+        </svg>
+      );
+    case "java":
+      return (
+        <svg viewBox="0 0 16 16" className={className ?? "h-3.5 w-3.5 flex-shrink-0"} fill="currentColor" style={{ color: "#E76F51" }}>
+          <path d="M4 1.5c.2-.5.6-1 1-1 .5 0 .8.5.8 1 0 .8-.8 1.5-.8 1.5s-.8-.7-.8-1.5zm3-.5c.2-.5.6-1 1-1 .5 0 .8.5.8 1 0 .8-.8 1.5-.8 1.5s-.8-.7-.8-1.5z" />
+          <path d="M2 5h8v4.5C10 11.4 8.4 13 6.5 13H5.5C3.6 13 2 11.4 2 9.5V5zm9 1h1c1.1 0 2 .9 2 2s-.9 2-2 2h-1V6z" />
+          <path d="M1 14h11v1H1v-1z" />
+        </svg>
+      );
+    case "rs":
+      return (
+        <svg viewBox="0 0 16 16" fill="none" className={className ?? "h-3.5 w-3.5 flex-shrink-0"}>
+          <rect width="16" height="16" rx="2.5" fill="#E45649" />
+          <text x="8" y="11" fill="white" fontSize="8" fontFamily="system-ui, -apple-system, sans-serif" fontWeight="800" textAnchor="middle">RS</text>
+        </svg>
+      );
+    case "csv":
+      return (
+        <svg viewBox="0 0 16 16" className={className ?? "h-3.5 w-3.5 flex-shrink-0"} fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: "#107C41" }}>
+          <rect x="2" y="2" width="12" height="12" rx="1.5" />
+          <line x1="2" y1="6" x2="14" y2="6" />
+          <line x1="2" y1="10" x2="14" y2="10" />
+          <line x1="7" y1="2" x2="7" y2="14" />
+        </svg>
+      );
+    case "json":
+      return (
+        <svg viewBox="0 0 16 16" className={className ?? "h-3.5 w-3.5 flex-shrink-0"} fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: "#F7A800" }}>
+          <rect x="2" y="2" width="12" height="12" rx="1.5" opacity="0.3" />
+          <text x="8" y="11.5" fill="#F7A800" fontSize="10" fontFamily="Courier New, monospace" fontWeight="bold" stroke="none" textAnchor="middle">{"{}"}</text>
+        </svg>
+      );
+    case "md":
+      return (
+        <svg viewBox="0 0 16 16" className={className ?? "h-3.5 w-3.5 flex-shrink-0"} fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: "#007ACC" }}>
+          <rect x="1.5" y="2.5" width="13" height="11" rx="1.5" />
+          <path d="M4 6.5l2 2 2-2M11.5 5.5v5m-1.5-1.5l1.5 1.5 1.5-1.5" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      );
+    default:
+      return (
+        <svg viewBox="0 0 16 16" className={className ?? "h-3.5 w-3.5 flex-shrink-0"} fill="none" stroke="currentColor" strokeWidth="1.5" style={{ color: "#94A3B8" }}>
+          <rect x="2.5" y="1.5" width="11" height="13" rx="1.5" />
+          <line x1="5.5" y1="5.5" x2="10.5" y2="5.5" strokeLinecap="round" />
+          <line x1="5.5" y1="8.5" x2="10.5" y2="8.5" strokeLinecap="round" />
+          <line x1="5.5" y1="11.5" x2="8.5" y2="11.5" strokeLinecap="round" />
+        </svg>
+      );
+  }
+}

--- a/apps/web/src/hooks/useCollaboration.ts
+++ b/apps/web/src/hooks/useCollaboration.ts
@@ -12,7 +12,10 @@ import type { Awareness } from "y-protocols/awareness";
 
 interface UseCollaborationReturn {
   readonly ydoc: Y.Doc | null;
+  /** @deprecated Use useWorkspace(ydoc, yworkspace) for multi-file workflows. */
   readonly ytext: Y.Text | null;
+  /** Shared Y.Map backing the workspace file/folder tree. */
+  readonly yworkspace: Y.Map<string> | null;
   readonly awareness: Awareness | null;
   readonly connected: boolean;
   readonly socket: Socket | null;
@@ -26,6 +29,7 @@ export function useCollaboration(config: SyncConnectionConfig): UseCollaboration
   const awarenessRef = useRef<Awareness | null>(null);
   const [ydoc, setYdoc] = useState<Y.Doc | null>(null);
   const [ytext, setYtext] = useState<Y.Text | null>(null);
+  const [yworkspace, setYworkspace] = useState<Y.Map<string> | null>(null);
   const [awareness, setAwareness] = useState<Awareness | null>(null);
   const [socketInstance, setSocketInstance] = useState<Socket | null>(null);
 
@@ -43,6 +47,7 @@ export function useCollaboration(config: SyncConnectionConfig): UseCollaboration
     setConnected(false);
     setYdoc(null);
     setYtext(null);
+    setYworkspace(null);
     setAwareness(null);
     setSocketInstance(null);
   }, []);
@@ -93,12 +98,13 @@ export function useCollaboration(config: SyncConnectionConfig): UseCollaboration
 
     setYdoc(collabDoc.ydoc);
     setYtext(collabDoc.ytext);
+    setYworkspace(collabDoc.yworkspace);
     setAwareness(awarenessInstance);
 
     return cleanup;
   }, [config.serverUrl, config.roomId, config.participant, cleanup]);
 
-  return { ydoc, ytext, awareness, connected, socket: socketInstance };
+  return { ydoc, ytext, yworkspace, awareness, connected, socket: socketInstance };
 }
 
 export function createDefaultParticipant(overrides?: Partial<Participant>): Participant {

--- a/apps/web/src/hooks/useWorkspace.ts
+++ b/apps/web/src/hooks/useWorkspace.ts
@@ -1,0 +1,270 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import * as Y from "yjs";
+import type {
+  WorkspaceFile,
+  WorkspaceFolder,
+  SupportedLanguage,
+} from "@tessera/shared-types";
+
+// ─────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────
+
+const EXTENSION_TO_LANGUAGE: Record<string, SupportedLanguage> = {
+  ts: "typescript",
+  tsx: "typescript",
+  js: "typescript",
+  py: "python",
+  cpp: "cpp",
+  cc: "cpp",
+  cxx: "cpp",
+  java: "java",
+  rs: "rust",
+};
+
+/** Derive the SupportedLanguage from a filename extension. */
+export function languageFromFilename(name: string): SupportedLanguage {
+  const ext = name.split(".").pop()?.toLowerCase() ?? "";
+  return EXTENSION_TO_LANGUAGE[ext] ?? "typescript";
+}
+
+function parseFiles(raw: string | undefined): WorkspaceFile[] {
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as WorkspaceFile[];
+  } catch {
+    return [];
+  }
+}
+
+function parseFolders(raw: string | undefined): WorkspaceFolder[] {
+  if (!raw) return [];
+  try {
+    return JSON.parse(raw) as WorkspaceFolder[];
+  } catch {
+    return [];
+  }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────
+
+export interface UseWorkspaceReturn {
+  /** Current list of files in the workspace. */
+  readonly files: readonly WorkspaceFile[];
+  /** Current list of folders in the workspace. */
+  readonly folders: readonly WorkspaceFolder[];
+  /** ID of the currently open file. */
+  readonly activeFileId: string | null;
+  /** Switch the editor to a different file. */
+  setActiveFileId(id: string): void;
+  /** Y.Text for the active file (to bind to Monaco). */
+  readonly activeYText: Y.Text | null;
+  /**
+   * Create a new file. Returns the new file's ID.
+   * @param name  e.g. "reader.py"
+   * @param parentFolderId  folder ID, or null for root level
+   */
+  createFile(name: string, parentFolderId?: string | null): string;
+  /** Create a new folder. Returns the new folder's ID. */
+  createFolder(name: string): string;
+  /** Rename a file by ID. */
+  renameFile(id: string, newName: string): void;
+  /** Rename a folder by ID. */
+  renameFolder(id: string, newName: string): void;
+  /**
+   * Delete a file by ID.
+   * If the deleted file is active, the hook automatically selects another.
+   */
+  deleteFile(id: string): void;
+  /**
+   * Delete a folder and all files inside it.
+   */
+  deleteFolder(id: string): void;
+  /** Get the Y.Text for any file by its ID (for execution collection). */
+  getYText(fileId: string): Y.Text | null;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Hook
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * Manages the multi-file workspace backed by a shared Yjs Y.Map.
+ * All mutations are synchronised to every collaborator automatically.
+ *
+ * @param ydoc     The shared Yjs document (from useCollaboration).
+ * @param yworkspace  The Y.Map("workspace") from the collaboration doc.
+ */
+export function useWorkspace(
+  ydoc: Y.Doc | null,
+  yworkspace: Y.Map<string> | null,
+): UseWorkspaceReturn {
+  const [files, setFiles] = useState<WorkspaceFile[]>([]);
+  const [folders, setFolders] = useState<WorkspaceFolder[]>([]);
+  const [activeFileId, setActiveFileId] = useState<string | null>(null);
+  const [activeYText, setActiveYText] = useState<Y.Text | null>(null);
+
+  // Keep track of the initial file ID so we can set it as active on first load.
+  const initialised = useRef(false);
+
+  // ── Sync from Yjs ──────────────────────────────────────────
+  useEffect(() => {
+    if (!yworkspace) return;
+
+    const sync = () => {
+      const newFiles = parseFiles(yworkspace.get("files"));
+      const newFolders = parseFolders(yworkspace.get("folders"));
+      setFiles(newFiles);
+      setFolders(newFolders);
+
+      // Auto-select the first file on initial load.
+      if (!initialised.current && newFiles.length > 0) {
+        initialised.current = true;
+        setActiveFileId(newFiles[0]!.id);
+      }
+    };
+
+    sync(); // Run once immediately in case the map is already populated.
+    yworkspace.observe(sync);
+
+    return () => {
+      yworkspace.unobserve(sync);
+    };
+  }, [yworkspace]);
+
+  // ── Sync active Y.Text ─────────────────────────────────────
+  useEffect(() => {
+    if (!ydoc || !activeFileId) {
+      setActiveYText(null);
+      return;
+    }
+    setActiveYText(ydoc.getText(activeFileId));
+  }, [ydoc, activeFileId]);
+
+  // ── Helpers ────────────────────────────────────────────────
+
+  const saveFiles = useCallback(
+    (updated: WorkspaceFile[]) => {
+      yworkspace?.set("files", JSON.stringify(updated));
+    },
+    [yworkspace],
+  );
+
+  const saveFolders = useCallback(
+    (updated: WorkspaceFolder[]) => {
+      yworkspace?.set("folders", JSON.stringify(updated));
+    },
+    [yworkspace],
+  );
+
+  // ── Mutations ──────────────────────────────────────────────
+
+  const createFile = useCallback(
+    (name: string, parentFolderId: string | null = null): string => {
+      const id = crypto.randomUUID();
+      const file: WorkspaceFile = {
+        id,
+        name,
+        language: languageFromFilename(name),
+        parentFolderId,
+      };
+      const current = parseFiles(yworkspace?.get("files"));
+      saveFiles([...current, file]);
+      setActiveFileId(id);
+      return id;
+    },
+    [yworkspace, saveFiles],
+  );
+
+  const createFolder = useCallback(
+    (name: string): string => {
+      const id = crypto.randomUUID();
+      const folder: WorkspaceFolder = { id, name };
+      const current = parseFolders(yworkspace?.get("folders"));
+      saveFolders([...current, folder]);
+      return id;
+    },
+    [yworkspace, saveFolders],
+  );
+
+  const renameFile = useCallback(
+    (id: string, newName: string) => {
+      const current = parseFiles(yworkspace?.get("files"));
+      saveFiles(
+        current.map((f) =>
+          f.id === id
+            ? { ...f, name: newName, language: languageFromFilename(newName) }
+            : f,
+        ),
+      );
+    },
+    [yworkspace, saveFiles],
+  );
+
+  const renameFolder = useCallback(
+    (id: string, newName: string) => {
+      const current = parseFolders(yworkspace?.get("folders"));
+      saveFolders(current.map((f) => (f.id === id ? { ...f, name: newName } : f)));
+    },
+    [yworkspace, saveFolders],
+  );
+
+  const deleteFile = useCallback(
+    (id: string) => {
+      const current = parseFiles(yworkspace?.get("files"));
+      const updated = current.filter((f) => f.id !== id);
+      saveFiles(updated);
+      // If the deleted file was active, select another.
+      setActiveFileId((prev) => {
+        if (prev !== id) return prev;
+        return updated[0]?.id ?? null;
+      });
+    },
+    [yworkspace, saveFiles],
+  );
+
+  const deleteFolder = useCallback(
+    (id: string) => {
+      const currentFiles = parseFiles(yworkspace?.get("files"));
+      const currentFolders = parseFolders(yworkspace?.get("folders"));
+      const updatedFiles = currentFiles.filter((f) => f.parentFolderId !== id);
+      const updatedFolders = currentFolders.filter((f) => f.id !== id);
+      saveFiles(updatedFiles);
+      saveFolders(updatedFolders);
+      // If active file was inside this folder, select another.
+      setActiveFileId((prev) => {
+        const wasInFolder = currentFiles.some(
+          (f) => f.id === prev && f.parentFolderId === id,
+        );
+        if (!wasInFolder) return prev;
+        return updatedFiles[0]?.id ?? null;
+      });
+    },
+    [yworkspace, saveFiles, saveFolders],
+  );
+
+  const getYText = useCallback(
+    (fileId: string): Y.Text | null => {
+      if (!ydoc) return null;
+      return ydoc.getText(fileId);
+    },
+    [ydoc],
+  );
+
+  return {
+    files,
+    folders,
+    activeFileId,
+    setActiveFileId,
+    activeYText,
+    createFile,
+    createFolder,
+    renameFile,
+    renameFolder,
+    deleteFile,
+    deleteFolder,
+    getYText,
+  };
+}

--- a/packages/collaboration/src/doc.ts
+++ b/packages/collaboration/src/doc.ts
@@ -3,7 +3,7 @@
 // ──────────────────────────────────────────────────────────────
 
 import * as Y from "yjs";
-import type { CollaborationRoom } from "@tessera/shared-types";
+import type { CollaborationRoom, WorkspaceFile, WorkspaceFolder } from "@tessera/shared-types";
 
 /**
  * Configuration for creating a collaborative document instance.
@@ -11,40 +11,96 @@ import type { CollaborationRoom } from "@tessera/shared-types";
 export interface CollaborationDocOptions {
   /** Room metadata to associate with this document. */
   readonly room: CollaborationRoom;
+  /** Initial file to seed the workspace with (defaults to main.ts). */
+  readonly initialFile?: Pick<WorkspaceFile, "id" | "name" | "language">;
 }
 
 /**
- * Wrapper around a Yjs Doc that provides typed access to
- * the shared text used by the Monaco editor binding.
+ * Wrapper around a Yjs Doc that provides typed access to the shared
+ * workspace: a metadata map for the file tree plus named Y.Text instances
+ * per file, all bound to the Monaco editor via y-monaco.
  */
 export interface CollaborationDoc {
   /** The underlying Yjs document. */
   readonly ydoc: Y.Doc;
-  /** The shared text type bound to the editor. */
+  /**
+   * Legacy single-file text reference — always points to the initial
+   * (first) file's Y.Text. Kept for backwards compatibility.
+   * Prefer `getFileText(fileId)` for multi-file workflows.
+   */
   readonly ytext: Y.Text;
+  /**
+   * Shared Y.Map that stores workspace metadata.
+   * Structure: { files: WorkspaceFile[], folders: WorkspaceFolder[] }
+   * serialised as JSON strings keyed by "files" and "folders".
+   */
+  readonly yworkspace: Y.Map<string>;
   /** Room metadata. */
   readonly room: CollaborationRoom;
+  /**
+   * Returns the Y.Text for a given file ID.
+   * Creates one lazily if it does not yet exist in the document.
+   */
+  getFileText(fileId: string): Y.Text;
   /** Tear down the document and free resources. */
   destroy(): void;
 }
 
+const DEFAULT_INITIAL_FILE: Pick<WorkspaceFile, "id" | "name" | "language"> = {
+  id: crypto.randomUUID(),
+  name: "main.ts",
+  language: "typescript",
+};
+
 /**
  * Creates a new Yjs document instance bound to a collaboration room.
  *
- * The returned `ytext` is the shared text type that should be bound
- * to Monaco via `y-monaco`, and to the sync-server via a WebSocket
- * provider.
+ * The document contains:
+ * - `yworkspace` Y.Map: serialised workspace tree (files + folders arrays).
+ * - Per-file `Y.Text` instances keyed by file ID (via `doc.getText(fileId)`).
+ *
+ * On first creation the workspace is seeded with one root-level file
+ * (defaults to `main.ts`). On subsequent joins the existing Yjs state
+ * is replayed from the server so the seed is a no-op.
  */
 export function createCollaborationDoc(
   options: CollaborationDocOptions,
 ): CollaborationDoc {
   const ydoc = new Y.Doc();
-  const ytext = ydoc.getText("monaco");
+  const yworkspace = ydoc.getMap<string>("workspace");
+  const initial = options.initialFile ?? DEFAULT_INITIAL_FILE;
+
+  // Seed the workspace tree only when the map is empty (first creator).
+  // Subsequent joins will receive the existing state from the sync-server.
+  if (yworkspace.size === 0) {
+    const initialFiles: WorkspaceFile[] = [
+      {
+        id: initial.id,
+        name: initial.name,
+        language: initial.language,
+        parentFolderId: null,
+      },
+    ];
+    const initialFolders: WorkspaceFolder[] = [];
+    yworkspace.set("files", JSON.stringify(initialFiles));
+    yworkspace.set("folders", JSON.stringify(initialFolders));
+  }
+
+  // Legacy ytext: the text for the very first file in the workspace.
+  // After the sync-step-2 exchange the actual first file ID may differ,
+  // so consumers should use getFileText() once they know the active file.
+  const ytext = ydoc.getText(initial.id);
+
+  function getFileText(fileId: string): Y.Text {
+    return ydoc.getText(fileId);
+  }
 
   return {
     ydoc,
     ytext,
+    yworkspace,
     room: options.room,
+    getFileText,
     destroy() {
       ydoc.destroy();
     },

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -17,15 +17,69 @@ export type ExecutionStatus =
   | "failed"
   | "timeout";
 
+// ─────────────────────────────────────────────────────────────
+// Workspace types (multi-file support)
+// ─────────────────────────────────────────────────────────────
+
+/**
+ * A single file in the multi-file workspace.
+ */
+export interface WorkspaceFile {
+  /** Unique stable identifier for this file (UUID). */
+  readonly id: string;
+  /** Display name including extension, e.g. "reader.py". */
+  name: string;
+  /** Programming language derived from the file extension. */
+  language: SupportedLanguage;
+  /**
+   * ID of the parent folder, or null if the file lives at the workspace root.
+   * MVP: single-level folders only (no nested subfolders).
+   */
+  parentFolderId: string | null;
+}
+
+/**
+ * A folder in the multi-file workspace.
+ * MVP: folders may only exist at the workspace root level.
+ */
+export interface WorkspaceFolder {
+  /** Unique stable identifier for this folder (UUID). */
+  readonly id: string;
+  /** Display name of the folder. */
+  name: string;
+}
+
+/**
+ * Full snapshot of the workspace tree.
+ */
+export interface WorkspaceTree {
+  readonly files: readonly WorkspaceFile[];
+  readonly folders: readonly WorkspaceFolder[];
+}
+
+/**
+ * A single file payload sent to the execution sandbox.
+ */
+export interface ExecutionFile {
+  /** Filename (used as path inside /tmp, e.g. "data.csv"). */
+  readonly name: string;
+  /** Full text content of the file. */
+  readonly content: string;
+}
+
+// ─────────────────────────────────────────────────────────────
+// Execution types
+// ─────────────────────────────────────────────────────────────
+
 /**
  * Payload submitted by a client to request code execution.
  */
 export interface ExecutionTask {
   /** Unique identifier for this execution job. */
   readonly id: string;
-  /** Source code to execute inside the sandbox. */
+  /** Source code of the active (entry-point) file to execute inside the sandbox. */
   readonly code: string;
-  /** Language runtime to use. */
+  /** Language runtime to use for the entry-point file. */
   readonly language: SupportedLanguage;
   /** Maximum execution duration in milliseconds. */
   readonly timeoutMs: number;
@@ -33,6 +87,11 @@ export interface ExecutionTask {
   readonly roomId: string;
   /** ISO-8601 timestamp of when the task was submitted. */
   readonly createdAt: string;
+  /**
+   * All workspace files to write into the sandbox /tmp directory
+   * before executing the entry-point. Includes the entry-point file itself.
+   */
+  readonly files: readonly ExecutionFile[];
 }
 
 /**
@@ -52,6 +111,10 @@ export interface ExecutionResult {
   /** Wall-clock execution duration in milliseconds. */
   readonly durationMs: number;
 }
+
+// ─────────────────────────────────────────────────────────────
+// Collaboration types
+// ─────────────────────────────────────────────────────────────
 
 /**
  * Metadata for a collaborative editing room.
@@ -93,6 +156,8 @@ export interface SyncClientToServerEvents {
   readonly "execute-code": (payload: {
     readonly code: string;
     readonly language: SupportedLanguage;
+    /** All workspace files to write into the sandbox before execution. */
+    readonly files: readonly ExecutionFile[];
   }) => void;
 }
 


### PR DESCRIPTION
## Description

This PR introduces a collaborative multi-file workspace system to Tessera.io, enabling users to create, organize, edit, and execute projects containing multiple files and folders in real time.

The implementation adds a synchronized workspace tree powered by Yjs, a new File Explorer UI with full CRUD operations, support for multi-file execution within the sandbox, and several editor experience improvements, including custom language-specific file icons and automatic language detection.

The execution engine now receives the complete workspace, allowing scripts to import local modules and interact with companion files such as datasets and configuration files.

Closes #169
Fixes #169 

<img width="1274" height="702" alt="image" src="https://github.com/user-attachments/assets/09372f29-31d0-4612-bba3-5c74b14c1321" />
<img width="1274" height="704" alt="image" src="https://github.com/user-attachments/assets/a061d914-000f-463e-9fff-519cc8a987c0" />


---

## Type of Change

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [ ] Documentation update
* [ ] Chore / Code maintenance (dependencies, workflows, formatting)

---

## How Has This Been Tested?

### Automated Verification

* [ ] `npm run lint` passes
* [x] `npm run typecheck` passes
* [ ] `npm run build` passes
* [ ] Existing/new tests pass (`npm run test`)

### Manual Verification

* [x] Verified local dev environment works (`npm run dev`)
* [x] Tested functionality in the browser / execution engine

#### Verification Performed

* Created, renamed, deleted, and organized files/folders within the workspace.
* Verified real-time synchronization of workspace changes across multiple connected clients.
* Confirmed dynamic Monaco editor rebinding when switching between files.
* Tested multi-file execution using a Python script (`reader.py`) that successfully read data from a companion file (`yulu_data.csv`).
* Verified custom language icons render correctly in both the File Explorer and editor breadcrumbs.
* Confirmed automatic language detection correctly assigns Monaco language modes based on file extensions.
* Verified CSV, TXT, and LOG files open in plaintext mode without incorrect syntax diagnostics.

---

## 👀 Maintainer Review Notes

### Automatic Language Detection

As part of the multi-file workspace experience, the manual language selector has been removed from the editor UI.

Language modes are now determined automatically from the active file's extension, ensuring the correct Monaco configuration is applied whenever a user switches files.


https://github.com/user-attachments/assets/6ec22658-ad4e-4325-99b4-f7ce74fa0a43



Benefits include:
* Better support for multi-language projects where different files require different editor modes.
* Automatic syntax highlighting and language services for supported file types.
* Plaintext handling for data files such as `.csv`, `.txt`, and `.log`, preventing unnecessary syntax warnings while preserving execution support.

This change is intentional and was introduced to provide a smoother workflow when working with multiple files within the same workspace.
However, if maintainers prefer to retain explicit language selection or would like support for manual overrides in specific workflows, I would be happy to update this implementation and reintroduce a language selector while preserving the automatic detection behavior.

The current architecture already supports language assignment programmatically, so adding a manual selector back would be straightforward if deemed beneficial for the project.

---

## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md) guidelines.
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [x] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings or console errors.