### PR TITLE
feat: add Go language support

### DIFF
--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -74,6 +74,7 @@ const LANGUAGE_IMAGES: Record<SupportedLanguage, string> = {
   cpp: "gcc:14",
   java: "eclipse-temurin:21-jdk-alpine",
   rust: "rust:1.75-slim",
+  go: "golang:1.20-alpine",
 };
 
 const LANGUAGE_COMMANDS: Record<
@@ -85,6 +86,11 @@ const LANGUAGE_COMMANDS: Record<
   cpp: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.cpp && g++ -o /tmp/main /tmp/main.cpp && /tmp/main`],
   java: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/Main.java && javac /tmp/Main.java -d /tmp && java -cp /tmp Main`],
   rust: (code) => ["sh", "-c", `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.rs && rustc /tmp/main.rs -o /tmp/main && /tmp/main`],
+  go: (code) => [
+  "sh",
+  "-c",
+  `echo '${code.replace(/'/g, "'\\''")}' > /tmp/main.go && go run /tmp/main.go`,
+],
 };
 
 const DEFAULT_MEMORY_LIMIT_MB = 256;

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,7 +17,7 @@ const FILE_NAMES: Record<SupportedLanguage, string> = {
   python: "main.py",
   cpp: "main.cpp",
   java: "Main.java",
-  rust: "main.rs"
+  rust: "main.rs",
   go: "main.go",
 };
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -18,6 +18,7 @@ const FILE_NAMES: Record<SupportedLanguage, string> = {
   cpp: "main.cpp",
   java: "Main.java",
   rust: "main.rs"
+  go: "main.go",
 };
 
 export function App() {
@@ -108,6 +109,7 @@ export function App() {
               <option value="cpp">C++</option>
               <option value="java">Java</option>
               <option value="rust">Rust</option>
+              <option value="go">Go</option>
             </select>
           </div>
 

--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -21,6 +21,7 @@ const LANGUAGE_MAP: Record<SupportedLanguage, string> = {
   cpp: "cpp",
   java: "java",
   rust: "rust"
+  go: "go",
 };
 
 export function CollaborativeEditor({

--- a/apps/web/src/components/CollaborativeEditor.tsx
+++ b/apps/web/src/components/CollaborativeEditor.tsx
@@ -20,7 +20,7 @@ const LANGUAGE_MAP: Record<SupportedLanguage, string> = {
   python: "python",
   cpp: "cpp",
   java: "java",
-  rust: "rust"
+  rust: "rust",
   go: "go",
 };
 

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -5,7 +5,7 @@
 /**
  * Supported programming languages for code execution.
  */
-export type SupportedLanguage = "typescript" | "python" | "cpp" | "java" | "rust";
+export type SupportedLanguage = "typescript" | "python" | "cpp" | "go" | "java" | "rust";
 
 /**
  * Status lifecycle of a code execution job.


### PR DESCRIPTION
## Description

Adds Go language support across the editor and execution engine.

### Changes made

* Extended 'SupportedLanguage' to include 'go'
* Added Go to the language selector dropdown
* Added 'main.go' file naming support
* Added Monaco editor language mapping for Go syntax highlighting
* Added Go runtime support in the execution engine:

  * Docker image: 'golang:1.20-alpine'
  * Go execution command pipeline

### Issues

Closes #64 
Closes #79 

### Verification

* [x] 'npm run typecheck'
* [x] 'npm run build'

