### PR TITLE
feat: add clear output button next to execution panel metrics

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -84,6 +84,7 @@ export function App() {
     if (!ytext) return;
     downloadTextFile(ytext.toString(), FILE_NAMES[language]);
   };
+
   return (
     <div className="flex h-screen flex-col bg-[var(--color-bg)]">
       {/* Header */}
@@ -138,6 +139,7 @@ export function App() {
               </>
             )}
           </button>
+          
           {/* Download Button */}
           <button
             onClick={handleDownload}
@@ -260,7 +262,7 @@ export function App() {
             Execution Output
           </p>
           {output && (
-            <div className="flex gap-4 text-xs font-medium">
+            <div className="flex items-center gap-4 text-xs font-medium">
               <span className={output.status === "completed" ? "text-emerald-400" : "text-rose-400"}>
                 Status: {output.status}
               </span>
@@ -272,9 +274,26 @@ export function App() {
                   Exit Code: {output.exitCode}
                 </span>
               )}
+              
+              {/* Vertical Separator for aesthetics */}
+              <span className="h-3 w-px bg-[var(--color-border)]" />
+
+              {/* Clear Output Button */}
+              <button
+                type="button"
+                onClick={() => setOutput(null)}
+                className="flex items-center gap-1 text-slate-400 hover:text-rose-400 hover:bg-rose-500/10 px-2 py-0.5 rounded transition duration-200 select-none cursor-pointer"
+                title="Clear execution output"
+              >
+                <svg className="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                </svg>
+                Clear
+              </button>
             </div>
           )}
         </div>
+        
         <div className="flex-1 overflow-y-auto font-mono text-xs p-2 rounded bg-[var(--color-bg)] border border-[var(--color-border)]">
           {isRunning ? (
             <span className="text-tessera-400 animate-pulse">Running execution sandbox...</span>


### PR DESCRIPTION
## Description
This PR addresses issue #20 by introducing a clean, intuitive "Clear Output" action button inside the console execution output panel. 

Previously, once code execution results (stdout/stderr) were printed onto the display panel, they remained visible indefinitely until the user triggered another code execution cycle. This enhancement adds a responsive button utilizing a garbage bin/trash icon alongside explicit text next to the panel's header metrics. Clicking this button resets the `output` state back to `null`, providing an un-cluttered arena for developers to manage their workspace layout.

**Key Changes:**
* Added a styled, hover-responsive `<button>` inside the conditional metadata layout of the output panel.
* Embedded a clean, clear SVG trash/bin icon within the button matching the dark, modern glassmorphism UI theme.
* Configured the button state to automatically hide itself when no active execution output text exists (`output === null`).

Closes #20

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run typecheck` passes
- [x] `npm run build` passes

### Manual Verification
- [x] Verified local dev environment works (`npm run dev`)
- [x] Tested functionality in the browser / execution engine
  - Bypassed execution engine constraints via frontend state mocking to test successful validation.
  - Confirmed the "Clear" button handles state transitions optimally: resets text fields, clears metadata logs, and disappears out of view on click.

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.

## Demo

https://github.com/user-attachments/assets/ac0b199d-40f8-4b9c-94bd-9b7a087fc668


