### PR TITLE
fix: make minimap switch toggle correctly

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -193,7 +193,10 @@ export function App() {
                 <label htmlFor="minimap-toggle" className="text-xs font-medium text-slate-300 cursor-pointer select-none">
                   Show Minimap
                 </label>
-                <div className="relative inline-flex items-center">
+                <label
+                  htmlFor="minimap-toggle"
+                  className="relative inline-flex items-center cursor-pointer"
+                >
                   <input
                     type="checkbox"
                     id="minimap-toggle"
@@ -201,8 +204,9 @@ export function App() {
                     onChange={(e) => setShowMinimap(e.target.checked)}
                     className="sr-only peer"
                   />
-                  <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600 cursor-pointer"></div>
-                </div>
+                  <div className="w-9 h-5 bg-slate-700 peer-focus:outline-none rounded-full peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-[2px] after:left-[2px] after:bg-white after:border-slate-300 after:border after:rounded-full after:h-4 after:w-4 after:transition-all peer-checked:bg-tessera-600"></div>
+                </label>
+
               </div>
 
               <div className="flex items-center justify-between">


### PR DESCRIPTION
## Description

Fixes the minimap toggle interaction issue in the editor settings sidebar.

Previously, clicking the "Show Minimap" text label correctly toggled the minimap, but clicking the visual switch itself did not trigger the checkbox state update because the visible switch UI was not properly associated with the hidden checkbox input.

This change wraps the custom switch component inside a `<label>` linked to the checkbox, ensuring the entire toggle area is clickable and behaves consistently.

Fixes #138

## Type of Change

* [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Automated Verification

* [ ] `npm run lint` passes
* [ ] `npm run typecheck` passes
* [ ] `npm run build` passes
* [ ] Existing/new tests pass (`npm run test`)

### Manual Verification

* [x] Verified local dev environment works (`npm run dev`)
* [x] Tested functionality in the browser / execution engine

Verified that:

* Clicking the “Show Minimap” label toggles the minimap
* Clicking the visual toggle switch also correctly toggles the minimap
* Toggle UI state remains synchronized with editor minimap visibility

## Checklist

* [x] I have read the [[CONTRIBUTING.md](https://chatgpt.com/c/CONTRIBUTING.md)](CONTRIBUTING.md) guidelines.
* [x] My code follows the style guidelines of this project.
* [x] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have made corresponding changes to the documentation.
* [x] My changes generate no new warnings or console errors.