### PR TITLE
feat(collaboration): log connection telemetry metrics for collaboration package

### DIFF
--- a/packages/collaboration/src/provider.ts
+++ b/packages/collaboration/src/provider.ts
@@ -8,6 +8,21 @@ export interface TesseraProviderOptions {
   readonly awareness: Awareness;
 }
 
+/**
+ * Connection diagnostics reported via console telemetry when a room
+ * session is established and when it is torn down. Helps developers
+ * spot slow handshakes or one-sided sync traffic during debugging.
+ */
+interface ConnectionTelemetry {
+  readonly synced: boolean;
+  readonly syncLatencyMs: number | null;
+  readonly sessionDurationMs: number;
+  readonly docUpdatesSent: number;
+  readonly docUpdatesReceived: number;
+  readonly awarenessUpdatesSent: number;
+  readonly awarenessUpdatesReceived: number;
+}
+
 export class TesseraSocketProvider {
   readonly ydoc: Y.Doc;
   readonly awareness: Awareness;
@@ -19,6 +34,15 @@ export class TesseraSocketProvider {
   private pendingAwarenessClients = new Set<number>();
   
   private static readonly AWARENESS_THROTTLE_MS = 50;
+
+  // Connection telemetry: timestamps/counters used to report sync
+  // latency and diagnostic stats when the session opens and closes.
+  private readonly sessionStartedAt = performance.now();
+  private syncLatencyMs: number | null = null;
+  private docUpdatesSent = 0;
+  private docUpdatesReceived = 0;
+  private awarenessUpdatesSent = 0;
+  private awarenessUpdatesReceived = 0;
 
   constructor(options: TesseraProviderOptions) {
     this.socket = options.socket;
@@ -50,6 +74,8 @@ export class TesseraSocketProvider {
     this.socket.off("sync-step-2", this.handleSyncStep2);
     this.socket.off("sync-update", this.handleSyncUpdate);
     this.socket.off("awareness-update", this.handleAwarenessRemoteUpdate);
+
+    console.info("[TesseraProvider] room session closed", this.getTelemetry());
   }
 
   /**
@@ -64,6 +90,18 @@ export class TesseraSocketProvider {
     this.ydoc.transact(() => {
       ytext.delete(0, ytext.length);
     });
+  }
+
+  private getTelemetry(): ConnectionTelemetry {
+    return {
+      synced: this.synced,
+      syncLatencyMs: this.syncLatencyMs,
+      sessionDurationMs: Math.round(performance.now() - this.sessionStartedAt),
+      docUpdatesSent: this.docUpdatesSent,
+      docUpdatesReceived: this.docUpdatesReceived,
+      awarenessUpdatesSent: this.awarenessUpdatesSent,
+      awarenessUpdatesReceived: this.awarenessUpdatesReceived,
+    };
   }
 
   private sendSyncStep1(): void {
@@ -95,7 +133,12 @@ export class TesseraSocketProvider {
   private readonly handleSyncStep2 = (data: Uint8Array): void => {
     try {
       Y.applyUpdate(this.ydoc, new Uint8Array(data), this);
-      this.synced = true;
+
+      if (!this.synced) {
+        this.synced = true;
+        this.syncLatencyMs = Math.round(performance.now() - this.sessionStartedAt);
+        console.info("[TesseraProvider] room session established", this.getTelemetry());
+      }
     } catch (err: unknown) {
       console.error("[TesseraProvider] sync-step-2 error:", err);
     }
@@ -104,6 +147,7 @@ export class TesseraSocketProvider {
   private readonly handleSyncUpdate = (data: Uint8Array): void => {
     try {
       Y.applyUpdate(this.ydoc, new Uint8Array(data), this);
+      this.docUpdatesReceived += 1;
     } catch (err: unknown) {
       console.error("[TesseraProvider] sync-update error:", err);
     }
@@ -115,6 +159,7 @@ export class TesseraSocketProvider {
   ): void => {
     if (origin === this) return;
     this.socket.emit("sync-update", update);
+    this.docUpdatesSent += 1;
   };
 
   private readonly handleAwarenessLocalUpdate = ({
@@ -144,6 +189,7 @@ export class TesseraSocketProvider {
       );
 
       this.socket.emit("awareness-update", encoded);
+      this.awarenessUpdatesSent += 1;
     }
 
     this.pendingAwarenessClients.clear();
@@ -153,6 +199,7 @@ export class TesseraSocketProvider {
   private readonly handleAwarenessRemoteUpdate = (data: Uint8Array): void => {
     try {
       applyAwarenessUpdate(this.awareness, new Uint8Array(data), this);
+      this.awarenessUpdatesReceived += 1;
     } catch (err: unknown) {
       console.error("[TesseraProvider] awareness-update error:", err);
     }


### PR DESCRIPTION
## Description

Adds console telemetry to `TesseraSocketProvider` (`@tessera/collaboration`) so developers can diagnose real-time sync issues without extra tooling.

- On the first successful `sync-step-2` (the initial CRDT handshake), logs `[TesseraProvider] room session established` with the measured sync latency.
- On `destroy()`, logs `[TesseraProvider] room session closed` with the total session duration and counts of doc/awareness updates sent and received during the session.

This is purely additive: no changes to the sync/awareness protocol itself, no new dependencies, and `destroy()` remains idempotent (telemetry logs exactly once per provider instance).

Fixes #30

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm run build` passes
- [x] Existing/new tests pass (`npm run test`) - `@tessera/collaboration` has no test script defined yet, so this remains a no-op via turbo, consistent with the package's current state (pre-existing, not introduced by this PR)

Run scoped to the affected package:
```
npx turbo run lint typecheck build --filter=@tessera/collaboration
```
All pass cleanly under the repo's strict `tsconfig` (`strict`, `noUnusedLocals`, `noUnusedParameters`, `noUncheckedIndexedAccess`, `verbatimModuleSyntax`).

### Manual Verification
- [x] Verified local dev environment works (`npm run dev`)

Since this is a focused change to a shared library, I wrote a standalone script that wires up two `TesseraSocketProvider` instances against real `yjs` / `y-protocols/awareness`, with an in-memory mock socket pair standing in for socket.io :

```
[TesseraProvider] room session established {
  synced: true,
  syncLatencyMs: 5,
  sessionDurationMs: 5,
  docUpdatesSent: 0,
  docUpdatesReceived: 0,
  awarenessUpdatesSent: 0,
  awarenessUpdatesReceived: 0
}
[TesseraProvider] room session closed {
  synced: false,
  syncLatencyMs: null,
  sessionDurationMs: 81,
  docUpdatesSent: 2,
  docUpdatesReceived: 0,
  awarenessUpdatesSent: 1,
  awarenessUpdatesReceived: 0
}
[TesseraProvider] room session closed {
  synced: true,
  syncLatencyMs: 5,
  sessionDurationMs: 81,
  docUpdatesSent: 0,
  docUpdatesReceived: 2,
  awarenessUpdatesSent: 0,
  awarenessUpdatesReceived: 1
}
```

Each side's "closed" log accurately reflects the doc/awareness traffic it sent and received (insert + `clearLocalDoc()` = 2 doc updates, 1 awareness change). The one provider that completes the handshake (`synced: true`) logs "established" exactly once with the measured latency; in production the sync-server always answers `sync-step-1`, so every real client logs
"established" once.

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.