### PR TITLE
fix(execution-engine): use numeric UID to fix "unable to find user sandbox" error

### DIFF
--- a/apps/execution-engine/src/sandbox.ts
+++ b/apps/execution-engine/src/sandbox.ts
@@ -145,7 +145,7 @@ export async function executeInSandbox(
     container = await docker.createContainer({
       Image: image,
       Cmd: cmd,
-      User: "sandbox",
+      User: "1000",
       WorkingDir: "/tmp",
       HostConfig: {
         Runtime: config.runtime,


### PR DESCRIPTION
## Description

The execution sandbox creates Docker containers with `User: "sandbox"`, but this named user does not exist in any of the base images (`node:20-slim`, `python:3.12-slim`, `gcc:14`, `eclipse-temurin:21-jdk-alpine`, `rust:1.75-slim`), causing every code execution to fail with:

```
(HTTP code 500) server error - unable to find user sandbox: no matching entries in passwd file
```

Switched to `User: "1000"` (numeric UID), which Docker supports natively without requiring a `/etc/passwd` entry. This maintains the same non-root security guarantee while working across all base images and platforms.

Fixes #197

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run typecheck` passes
- [x] `npm run build` passes

### Manual Verification
- [x] Verified local dev environment works (`npm run dev`)
- [x] Tested functionality in the browser / execution engine - code executes successfully after the fix

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.