### PR TITLE
fix(web): reset editor contents when switching language

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from "react";
+import { useMemo, useState, useEffect, type ChangeEvent } from "react";
 import { SidePanel } from "@tessera/ui-components";
 import { CollaborativeEditor } from "./components/CollaborativeEditor.js";
 import {
@@ -19,6 +19,15 @@ const FILE_NAMES: Record<SupportedLanguage, string> = {
   java: "Main.java",
   rust: "main.rs",
   go: "main.go",
+};
+
+const STARTER_CODE: Record<SupportedLanguage, string> = {
+  typescript: 'console.log("Hello from TypeScript");\n',
+  python: 'print("Hello from Python")\n',
+  cpp: '#include <iostream>\n\nint main() {\n  std::cout << "Hello from C++" << std::endl;\n  return 0;\n}\n',
+  java: 'public class Main {\n  public static void main(String[] args) {\n    System.out.println("Hello from Java");\n  }\n}\n',
+  rust: 'fn main() {\n    println!("Hello from Rust");\n}\n',
+  go: 'package main\n\nimport "fmt"\n\nfunc main() {\n  fmt.Println("Hello from Go")\n}\n',
 };
 
 export function App() {
@@ -81,6 +90,41 @@ export function App() {
     });
   };
 
+  const handleLanguageChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextLanguage = event.target.value as SupportedLanguage;
+    if (nextLanguage === language) return;
+
+    if (!ytext) {
+      setLanguage(nextLanguage);
+      return;
+    }
+
+    const currentCode = ytext.toString();
+    if (currentCode.trim().length > 0) {
+      const shouldReplace = window.confirm(
+        `Switching to ${nextLanguage} will replace the current editor contents with ${FILE_NAMES[nextLanguage]} starter code. Continue?`,
+      );
+
+      if (!shouldReplace) return;
+    }
+
+    const replaceContents = () => {
+      if (ytext.length > 0) {
+        ytext.delete(0, ytext.length);
+      }
+      ytext.insert(0, STARTER_CODE[nextLanguage]);
+    };
+
+    if (ytext.doc) {
+      ytext.doc.transact(replaceContents);
+    } else {
+      replaceContents();
+    }
+
+    setLanguage(nextLanguage);
+    setOutput(null);
+  };
+
   const handleDownload = () => {
     if (!ytext) return;
     downloadTextFile(ytext.toString(), FILE_NAMES[language]);
@@ -101,7 +145,7 @@ export function App() {
             <span className="text-xs text-slate-400">Language:</span>
             <select
               value={language}
-              onChange={(e) => setLanguage(e.target.value as SupportedLanguage)}
+              onChange={handleLanguageChange}
               className="bg-[var(--color-bg)] text-sm text-white border border-[var(--color-border)] rounded px-2 py-1 focus:outline-none focus:border-tessera-500 font-medium"
             >
               <option value="typescript">TypeScript</option>


### PR DESCRIPTION
## Description
Fixes the language-switch behavior in the web editor so code from one runtime is not accidentally executed in another runtime.

When a user changes the language dropdown, the app now prompts for confirmation if the editor has existing content. If confirmed, the shared editor content is replaced with starter code for the selected language and the previous execution output is cleared.

Fixes #184 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran the web workspace typecheck to verify the React/TypeScript changes compile successfully.

### Automated Verification
- [ ] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Existing/new tests pass (`npm run test`)

### Manual Verification
- [ ] Verified local dev environment works (`npm run dev`)
- [ ] Tested functionality in the browser / execution engine

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.