### PR TITLE
fix(ai-service): embed RAG chunks during ingestion

### DIFF
--- a/apps/ai-service/src/embeddings.py
+++ b/apps/ai-service/src/embeddings.py
@@ -3,13 +3,13 @@
 import asyncio
 from functools import lru_cache
 
-from sentence_transformers import SentenceTransformer
-
 from .config import settings
 
 
 @lru_cache(maxsize=1)
-def _load_model(model_name: str) -> SentenceTransformer:
+def _load_model(model_name: str):
+    from sentence_transformers import SentenceTransformer
+
     return SentenceTransformer(model_name)
 
 
@@ -20,7 +20,16 @@ class EmbeddingService:
         self.model_name = model_name
 
     async def embed_query(self, text: str) -> list[float]:
+        return (await self.embed_documents([text]))[0]
+
+    async def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        if not texts:
+            return []
+
         loop = asyncio.get_running_loop()
         model = _load_model(self.model_name)
-        vector = await loop.run_in_executor(None, model.encode, text)
-        return vector.tolist()
+        vectors = await loop.run_in_executor(None, model.encode, texts)
+        return [
+            vector.tolist() if hasattr(vector, "tolist") else list(vector)
+            for vector in vectors
+        ]

--- a/apps/ai-service/src/main.py
+++ b/apps/ai-service/src/main.py
@@ -82,9 +82,7 @@ async def health_check() -> JSONResponse:
     models = {
         "mcp_server": settings.MCP_SERVER_NAME,
         "embedding_dimensions": settings.EMBEDDING_DIMENSIONS,
-        # The embedding pipeline is still a placeholder vector (see rag.py);
-        # surfaced here so operators can see it is not a real provider yet.
-        "embedding_provider": "placeholder",
+        "embedding_provider": settings.EMBEDDING_MODEL,
     }
 
     healthy = bool(database["connected"])

--- a/apps/ai-service/src/rag.py
+++ b/apps/ai-service/src/rag.py
@@ -1,9 +1,10 @@
 from fastapi import APIRouter
 from pydantic import BaseModel, Field
 from .db import get_collection
-from .config import settings
+from .embeddings import EmbeddingService
 
 router = APIRouter(prefix="/rag", tags=["RAG"])
+embedding_service = EmbeddingService()
 
 
 class IngestRequest(BaseModel):
@@ -55,15 +56,13 @@ def _split_into_chunks(text: str, chunk_size: int) -> list[str]:
 async def ingest(req: IngestRequest) -> IngestResponse:
     collection = get_collection()
     chunks = _split_into_chunks(req.content, req.chunk_size)
-
-    # Placeholder embedding — replace with real embedding provider later
-    placeholder_vector = [0.0] * settings.EMBEDDING_DIMENSIONS
+    embeddings = await embedding_service.embed_documents(chunks)
 
     documents = [
         {
             "file_path": req.file_path,
             "content": chunk,
-            "embedding": placeholder_vector,
+            "embedding": embeddings[idx],
             "chunk_index": idx,
         }
         for idx, chunk in enumerate(chunks)

--- a/apps/ai-service/tests/test_rag.py
+++ b/apps/ai-service/tests/test_rag.py
@@ -1,0 +1,65 @@
+import asyncio
+
+from src import rag
+
+
+class _FakeCollection:
+    def __init__(self) -> None:
+        self.inserted_documents = []
+
+    async def insert_many(self, documents):
+        self.inserted_documents.extend(documents)
+
+
+class _FakeEmbeddingService:
+    def __init__(self) -> None:
+        self.texts = []
+
+    async def embed_documents(self, texts: list[str]) -> list[list[float]]:
+        self.texts = texts
+        return [[float(index + 1), float(index + 2)] for index, _ in enumerate(texts)]
+
+
+def test_ingest_embeds_chunks_before_storing(monkeypatch):
+    collection = _FakeCollection()
+    embedding_service = _FakeEmbeddingService()
+
+    monkeypatch.setattr(rag, "get_collection", lambda: collection)
+    monkeypatch.setattr(rag, "embedding_service", embedding_service)
+
+    response = asyncio.run(
+        rag.ingest(
+            rag.IngestRequest(
+                file_path="src/example.ts",
+                content="alpha beta gamma delta",
+                chunk_size=64,
+            )
+        )
+    )
+
+    assert response.chunks_stored == 1
+    assert embedding_service.texts == ["alpha beta gamma delta"]
+    assert collection.inserted_documents == [
+        {
+            "file_path": "src/example.ts",
+            "content": "alpha beta gamma delta",
+            "embedding": [1.0, 2.0],
+            "chunk_index": 0,
+        }
+    ]
+
+
+def test_ingest_skips_embedding_when_no_chunks(monkeypatch):
+    collection = _FakeCollection()
+    embedding_service = _FakeEmbeddingService()
+
+    monkeypatch.setattr(rag, "get_collection", lambda: collection)
+    monkeypatch.setattr(rag, "embedding_service", embedding_service)
+
+    response = asyncio.run(
+        rag.ingest(rag.IngestRequest(file_path="empty.py", content="", chunk_size=64))
+    )
+
+    assert response.chunks_stored == 0
+    assert embedding_service.texts == []
+    assert collection.inserted_documents == []


### PR DESCRIPTION
## Description
Replaces the placeholder zero-vector embedding used by `/rag/ingest` with real embeddings generated through the existing `EmbeddingService`.

Ingested chunks are now embedded with the configured sentence-transformers model before being stored in MongoDB, making Atlas Vector Search rankings meaningful instead of treating every chunk as equally distant. This also updates health metadata to report the configured embedding model and adds tests for the ingestion path.

Fixes #183 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran the full AI service pytest suite and lint/format checks.

### Automated Verification
- [x] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [x] Existing/new tests pass (`npm run test`)

### Manual Verification
- [ ] Verified local dev environment works (`npm run dev`)
- [ ] Tested functionality in the browser / execution engine

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.