### PR TITLE
fix(web): read sync server URL from environment

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -9,7 +9,9 @@ import { isMacOS, getExecutionShortcutText } from "./utils/platformDetection.js"
 import type { SyncConnectionConfig, SupportedLanguage, ExecutionResult } from "@tessera/shared-types";
 import { downloadTextFile } from "./utils/downloadUtils.js";
 
-const SYNC_SERVER_URL = "http://localhost:4000";
+const DEFAULT_SYNC_SERVER_URL = "http://localhost:4000";
+const SYNC_SERVER_URL =
+  import.meta.env.VITE_SYNC_SERVER_URL ?? DEFAULT_SYNC_SERVER_URL;
 const DEFAULT_ROOM = "default-room";
 
 const FILE_NAMES: Record<SupportedLanguage, string> = {


### PR DESCRIPTION
## Description
Makes the web app sync server endpoint configurable through `import.meta.env.VITE_SYNC_SERVER_URL`, with `http://localhost:4000` kept as the local development fallback.

This matches the existing environment-based pattern used by the AI service client and allows staging or production deployments to point the frontend at a remote sync server without changing source code.

Fixes #182 

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran the web workspace TypeScript check to verify the Vite env usage compiles successfully.

### Automated Verification
- [ ] `npm run lint` passes
- [x] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Existing/new tests pass (`npm run test`)

### Manual Verification
- [ ] Verified local dev environment works (`npm run dev`)
- [ ] Tested functionality in the browser / execution engine

## Checklist
- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.