### PR TITLE
feat(ci): integrate GitHub CodeQL analysis for TypeScript and Python

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,65 @@
+name: 'CodeQL Advanced'
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+  schedule:
+    # Runs at 15:34, only on Sunday
+    - cron: '34 15 * * 0'
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+
+    # Consider using larger runners or machines with greater resources for possible analysis time improvements.
+    runs-on: ${{ (matrix.language == 'swift' && 'macos-latest') || 'ubuntu-latest' }}
+    permissions:
+      # required for all workflows
+      security-events: write
+
+      # required to fetch internal or private CodeQL packs
+      packages: read
+
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      # If the analyze step fails for one of the languages you are analyzing with
+      # "We were unable to automatically build your code", modify the matrix above to set the build mode to "manual" for that language. Then modify this step to build your code.
+      - name: Run manual build steps
+        if: matrix.build-mode == 'manual'
+        shell: bash
+        run: |
+          echo 'If you are using a "manual" build mode for one or more of the' \
+            'languages you are analyzing, replace this with the commands to build' \
+            'your code, for example:'
+          echo '  make bootstrap'
+          echo '  make release'
+          exit 1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: '/language:${{matrix.language}}'


### PR DESCRIPTION
## Related issue
Fixes #150

## Description

This PR introduces a dedicated GitHub CodeQL workflow to add automated static application security testing (SAST) for the repository.

### What was added

* Added `.github/workflows/codeql.yml`
* Configured CodeQL analysis for:
  * TypeScript / JavaScript
  * Python
* Enabled execution on:
  * Push events
  * Pull request events
  * Weekly scheduled scans
* Configured SARIF upload for GitHub Code Scanning integration
* Used GitHub's recommended CodeQL security analysis configuration

### Why

The repository currently includes automation for contributor workflows and repository maintenance, but lacks continuous security analysis.

Adding CodeQL provides automated detection of security vulnerabilities, insecure coding patterns, and potential quality issues during the development lifecycle while integrating natively with GitHub Security features.

## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [x] Chore / Code maintenance (dependencies, workflows, formatting)

## How Has This Been Tested?

### Automated Verification

* [ ] `npm run lint` passes
* [ ] `npm run typecheck` passes
* [ ] `npm run build` passes
* [ ] Existing/new tests pass (`npm run test`)

### Manual Verification

* [x] Verified workflow YAML syntax and configuration
* [x] Confirmed CodeQL matrix configuration for TypeScript and Python
* [x] Verified workflow triggers for push, pull_request, and scheduled execution
* [x] Confirmed SARIF upload step is configured for GitHub Code Scanning


## Checklist
- [X] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [X] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings or console errors.
