### PR TITLE
fix(ai-service): split oversized tokens so RAG chunks respect chunk_size

### DIFF
--- a/apps/ai-service/src/rag.py
+++ b/apps/ai-service/src/rag.py
@@ -37,16 +37,33 @@ def _split_into_chunks(text: str, chunk_size: int) -> list[str]:
     current: list[str] = []
     current_len = 0
 
-    for word in words:
-        if current_len + len(word) + 1 > chunk_size and current:
+    def flush() -> None:
+        nonlocal current, current_len
+        if current:
             chunks.append(" ".join(current))
             current = []
             current_len = 0
+
+    for word in words:
+        # A single token longer than chunk_size can never fit in a normal chunk.
+        # The previous logic appended it whole (the `and current` guard skipped
+        # the split when the chunk was empty), producing a chunk larger than
+        # chunk_size. Hard-split such tokens into chunk_size-sized pieces so every
+        # returned chunk respects the limit — otherwise an oversized chunk would
+        # later exceed the embedding model's token limit. This matters for code
+        # ingestion, where long URLs, base64 blobs, and minified lines are common.
+        if len(word) > chunk_size:
+            flush()
+            for i in range(0, len(word), chunk_size):
+                chunks.append(word[i : i + chunk_size])
+            continue
+
+        if current_len + len(word) + 1 > chunk_size and current:
+            flush()
         current.append(word)
         current_len += len(word) + 1
 
-    if current:
-        chunks.append(" ".join(current))
+    flush()
 
     return chunks
 

--- a/apps/ai-service/tests/test_rag_chunking.py
+++ b/apps/ai-service/tests/test_rag_chunking.py
@@ -1,0 +1,68 @@
+"""Tests for RAG text chunking (`src.rag._split_into_chunks`).
+
+These verify the core invariant that every returned chunk respects `chunk_size`,
+including the edge case where a single token is longer than `chunk_size`. No
+MongoDB or embedding service is required.
+"""
+
+from src.rag import _split_into_chunks
+
+
+def test_empty_text_returns_no_chunks():
+    assert _split_into_chunks("", 64) == []
+    assert _split_into_chunks("   ", 64) == []
+
+
+def test_short_text_is_a_single_chunk():
+    assert _split_into_chunks("hello world", 64) == ["hello world"]
+
+
+def test_normal_text_splits_into_multiple_chunks():
+    text = " ".join(f"word{i}" for i in range(50))
+    chunks = _split_into_chunks(text, 32)
+    assert len(chunks) > 1
+
+
+def test_every_chunk_respects_chunk_size_for_normal_text():
+    text = " ".join(f"token{i}" for i in range(200))
+    chunk_size = 40
+    for chunk in _split_into_chunks(text, chunk_size):
+        assert len(chunk) <= chunk_size
+
+
+def test_normal_text_is_preserved_in_order():
+    # When no token is hard-split, re-joining the chunks must reproduce the input.
+    text = " ".join(f"w{i}" for i in range(120))
+    chunks = _split_into_chunks(text, 50)
+    assert " ".join(chunks).split() == text.split()
+
+
+def test_oversized_single_token_is_hard_split():
+    # Regression: previously this returned one chunk of length 33 for chunk_size 10.
+    chunk_size = 10
+    word = "x" * 33
+    chunks = _split_into_chunks(word, chunk_size)
+
+    assert all(len(c) <= chunk_size for c in chunks)
+    # No characters lost or added by the hard split.
+    assert "".join(chunks) == word
+    assert chunks == ["x" * 10, "x" * 10, "x" * 10, "x" * 3]
+
+
+def test_oversized_token_among_normal_words():
+    chunk_size = 12
+    text = f"alpha beta {'z' * 30} gamma"
+    chunks = _split_into_chunks(text, chunk_size)
+
+    assert all(len(c) <= chunk_size for c in chunks)
+    # The long token's characters survive intact across the hard-split pieces.
+    assert "".join(chunks).count("z") == 30
+    # Surrounding words are still present.
+    joined = " ".join(chunks)
+    assert "alpha" in joined and "beta" in joined and "gamma" in joined
+
+
+def test_token_exactly_chunk_size_is_one_chunk():
+    chunk_size = 8
+    word = "a" * 8
+    assert _split_into_chunks(word, chunk_size) == [word]


### PR DESCRIPTION
## Description

Fixes #493.

`_split_into_chunks` in `apps/ai-service/src/rag.py` could return a chunk larger than `chunk_size`: when a single token is longer than `chunk_size` and the current chunk is empty, the `and current` guard skipped the split, so the oversized token was appended whole and flushed as its own chunk. For a code-ingesting RAG service this happens with long URLs, base64 blobs, minified lines, and long identifiers, and it would exceed the embedding model's token limit once the placeholder embedder is replaced (the `# replace with real embedding provider later` TODO in `ingest`).

This PR hard-splits any token longer than `chunk_size` into `chunk_size`-sized pieces, so the function now guarantees `len(chunk) <= chunk_size` for every chunk. Normal multi-word chunking is unchanged; the flush logic is factored into a small helper to avoid duplication.

### Before / After

```python
# chunk_size = 10
_split_into_chunks("x" * 33, 10)
# before: ['xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx']      # len 33 > 10  (bug)
# after:  ['xxxxxxxxxx', 'xxxxxxxxxx', 'xxxxxxxxxx', 'xxx']   # all <= 10
```

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

### Automated Verification
- [x] Added `apps/ai-service/tests/test_rag_chunking.py` (8 tests) covering: empty input, normal multi-chunk splitting, the `len(chunk) <= chunk_size` invariant, word-order preservation, the oversized-token regression, an oversized token among normal words, and the exact-`chunk_size` boundary.
- [x] `ruff check` and `ruff format --check` are clean on the changed files.

The change is pure logic with no external dependencies, so the tests need no MongoDB or embedding service. (`ai-service` deps require Python >= 3.10, so the full `pytest tests/` runs under the repo's CI on Python 3.11.)

## Checklist
- [x] My commits are **signed off** using `git commit -s`.
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation. (No user-facing docs affected — internal RAG helper.)
- [x] My changes generate no new warnings or console errors.
