### PR TITLE
feat(web): add dynamic light theme CSS variables

### DIFF
--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -25,14 +25,48 @@
 
   --color-bg: #0f1117;
   --color-surface: #161822;
+  --color-primary: #5c7cfa;
+  --color-secondary: #4263eb;
+  --color-accent: #748ffc;
+  --color-text-primary: #e2e8f0;
+  --color-text-secondary: #94a3b8;
   --color-border: #2a2d3a;
+  --color-shadow: rgba(0, 0, 0, 0.5);
+  --color-editor-bg: #0d1117;
+  --color-editor-fg: #e2e8f0;
+  --color-selection: rgba(92, 124, 250, 0.3);
+  --color-hover: rgba(255, 255, 255, 0.05);
+  --color-success: #22c55e;
+  --color-warning: #f59e0b;
+  --color-error: #ef4444;
+}
+
+[data-theme="light"] {
+  color-scheme: light;
+
+  --color-bg: #ffffff;
+  --color-surface: #f8fafc;
+  --color-primary: #4c6ef5;
+  --color-secondary: #3b5bdb;
+  --color-accent: #5c7cfa;
+  --color-text-primary: #0f172a;
+  --color-text-secondary: #475569;
+  --color-border: #e2e8f0;
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-editor-bg: #fafafa;
+  --color-editor-fg: #1e293b;
+  --color-selection: rgba(76, 110, 245, 0.2);
+  --color-hover: rgba(0, 0, 0, 0.05);
+  --color-success: #16a34a;
+  --color-warning: #d97706;
+  --color-error: #dc2626;
 }
 
 body {
   margin: 0;
   min-height: 100vh;
   background-color: var(--color-bg);
-  color: #e2e8f0;
+  color: var(--color-text-primary);
 }
 
 #root {


### PR DESCRIPTION
## Description

Implements dynamic light theme support via CSS custom properties, resolving the absence of a light theme in the design system.

Extends `:root` from 3 variables to a complete 16-variable dark theme token set, then adds a `[data-theme="light"]` block that overrides all 16 tokens with accessible light values. The `body` text colour is updated from a hardcoded value to `var(--color-text-primary)` so it responds to the theme switch.

To activate the light theme, set `data-theme="light"` on the `<html>` or `<body>` element.

Fixes #43

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

### Manual Verification

- [x] Verified local dev environment works (`npm run dev`)
- [x] Adding `data-theme="light"` to `<body>` correctly overrides all colour tokens
- [x] Removing `data-theme="light"` restores the dark theme without any conflicts
- [x] No duplicated rules — only CSS variable overrides are added in the light theme block
- [x] All 16 tokens provide sufficient contrast and pass visual accessibility checks

## Checklist

- [x] I have read the [CONTRIBUTING.md](CONTRIBUTING.md) guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.
