### PR TITLE
feat(sync-server): configure ESLint with flat config

### DIFF
--- a/apps/sync-server/eslint.config.js
+++ b/apps/sync-server/eslint.config.js
@@ -1,0 +1,10 @@
+import eslint from '@eslint/js';
+import tseslint from 'typescript-eslint';
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ['dist', 'node_modules'],
+  }
+);

--- a/apps/sync-server/package.json
+++ b/apps/sync-server/package.json
@@ -9,7 +9,7 @@
     "start": "node dist/server.js",
     "typecheck": "tsc --noEmit",
     "clean": "rm -rf dist",
-    "lint": "echo 'lint not configured yet'"
+    "lint": "eslint ."
   },
   "dependencies": {
     "@tessera/shared-types": "*",
@@ -23,7 +23,9 @@
   },
   "devDependencies": {
     "@types/express": "^5.0.0",
+    "eslint": "^9.30.1",
     "tsx": "^4.22.3",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "typescript-eslint": "^8.35.1"
   }
 }


### PR DESCRIPTION
## Description
Replaces the placeholder `lint` script in `apps/sync-server` with a working ESLint 9 flat config setup, matching the monorepo standard established in `packages/shared-types`. Adds `eslint` and `typescript-eslint` as devDependencies and creates `eslint.config.js` applying `eslint.configs.recommended` and `tseslint.configs.recommended` with `dist/` and `node_modules/` ignored.

Fixes #19

## Type of Change
- [x] Chore / Code maintenance (dependencies, workflows, formatting)

## How Has This Been Tested?

### Automated Verification
- [x] `npm run lint` passes — `npm run lint --workspace=@tessera/sync-server` completes with zero errors
- [x] `npm run build` passes — root `npm run build` compiles all packages successfully

### Manual Verification
- [x] Introduced a temporary unused variable (`const unusedVar = "hello"`) in `src/server.ts` — ESLint correctly flagged `@typescript-eslint/no-unused-vars`, confirming rules are active
- [x] Verified root `npm run lint` (turbo) runs lint across all packages including the newly configured `sync-server`

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or console errors.