### PR TITLE
docs: fix inconsistency between MongoDB Atlas mention and local Docker setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The current repository is the foundational MVP. We have established the core plu
 *   **Real-Time Collaboration:** Powered by Yjs (CRDTs) and Socket.io, ensuring deterministic, conflict-free state resolution across clients.
 *   **The Editor:** React + TailwindCSS utilizing `@monaco-editor/react` for a native VS Code-like typing experience.
 *   **Secure Execution Engine:** A Node.js worker utilizing BullMQ and the Docker Engine API to run untrusted code safely in isolated, ephemeral containers (with optional gVisor support).
-*   **AI Service Foundation:** A lightweight Python/FastAPI service hooked into the Model Context Protocol (MCP) and MongoDB Atlas Vector Search for RAG pipelines.
+*   **AI Service Foundation:** A lightweight Python/FastAPI service hooked into the Model Context Protocol (MCP) and MongoDB Vector Search for RAG pipelines.
 
 ---
 


### PR DESCRIPTION
## Description
Fixed a factual inconsistency in README.md — the "AI Service Foundation" bullet claimed the project uses "MongoDB Atlas Vector Search" (a cloud-only managed feature), but the Prerequisites section states local development just needs a plain Docker MongoDB container, which isn't Atlas. Removed the "Atlas" qualifier for consistency.

Fixes #None (just a documentation quick fix)

## Type of Change
- [x] Documentation update

## How Has This Been Tested?
### Automated Verification
- [ ] `npm run lint` passes
- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes
- [ ] Existing/new tests pass (`npm run test`)

### Manual Verification
- [x] Cross-checked the wording against the Prerequisites/local setup instructions in the same README

## Checklist
- [x] I have read the CONTRIBUTING.md guidelines.
- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings or console errors.